### PR TITLE
mapping hiking routes properties OC:5776

### DIFF
--- a/app/Console/Commands/GetTaxonomyWheresFromOsmfeaturesCommand.php
+++ b/app/Console/Commands/GetTaxonomyWheresFromOsmfeaturesCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\HikingRoute;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use App\Jobs\GetTaxonomyWheresFromOsmfeaturesJob;
+
+class GetTaxonomyWheresFromOsmfeaturesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'osm2cai:get-taxonomy-wheres-from-osmfeatures';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This command dispatch jobs to get taxonomy wheres from osmfeatures';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info('Fetching hiking routes with geometry...');
+        $hikingRoutes = HikingRoute::whereNotNull('geometry')->get(['id', 'geometry', 'properties']);
+
+        $total = $hikingRoutes->count();
+        $this->info("Found {$total} hiking routes to process.");
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        foreach ($hikingRoutes as $route) {
+            dispatch(new GetTaxonomyWheresFromOsmfeaturesJob($route))->onQueue('geometric-computations');
+            $bar->advance();
+        }
+
+        $bar->finish();
+        $this->newLine();
+        $this->info("Dispatching complete. {$total} jobs dispatched.");
+    }
+}

--- a/app/Console/Commands/PopulateHikingRoutesPropertiesCommand.php
+++ b/app/Console/Commands/PopulateHikingRoutesPropertiesCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\HikingRoute;
+use Illuminate\Console\Command;
+
+final class PopulateHikingRoutesPropertiesCommand extends Command
+{
+    protected $signature = 'osm2cai:populate-hiking-routes-properties 
+                           {--chunk=100 : Number of records to process at once}';
+
+    protected $description = 'Populate the properties column of hiking routes with data extracted from osmfeatures_data for Elasticsearch';
+
+    public function handle(): int
+    {
+        $this->info('Starting to populate hiking routes properties...');
+
+        $hikingRoutes = HikingRoute::whereNotNull(['osmfeatures_data', 'properties'])->get();
+        $totalRoutes = $hikingRoutes->count();
+
+        $this->info("Found {$totalRoutes} hiking routes with osmfeatures_data");
+
+        if ($totalRoutes === 0) {
+            $this->warn('No hiking routes found with osmfeatures_data');
+            return Command::SUCCESS;
+        }
+
+        $processedCount = 0;
+        $updatedCount = 0;
+        $errorCount = 0;
+
+        $progressBar = $this->output->createProgressBar($totalRoutes);
+        $progressBar->start();
+
+        foreach ($hikingRoutes as $hikingRoute) {
+            try {
+                $properties = HikingRoute::extractPropertiesFromOsmfeatures($hikingRoute->osmfeatures_data);
+                $hikingRoute->updateQuietly(['properties' => $properties]);
+                ++$updatedCount;
+                ++$processedCount;
+            } catch (\Throwable $e) {
+                ++$errorCount;
+                $this->error("\nError processing HikingRoute ID {$hikingRoute->id}: {$e->getMessage()}");
+            }
+            $progressBar->advance();
+        }
+
+        $progressBar->finish();
+
+        $this->newLine(2);
+        $this->info('Process completed!');
+        $this->table(
+            ['Metric', 'Count'],
+            [
+                ['Total Processed', $processedCount],
+                ['Successfully Updated', $updatedCount],
+                ['Errors', $errorCount],
+            ]
+        );
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Jobs/GetTaxonomyWheresFromOsmfeaturesJob.php
+++ b/app/Jobs/GetTaxonomyWheresFromOsmfeaturesJob.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class GetTaxonomyWheresFromOsmfeaturesJob implements ShouldQueue
+{
+    use Queueable;
+
+    public $model;
+    public $osmfeaturesApi;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct($model)
+    {
+        $this->model = $model;
+        $this->osmfeaturesApi = 'https://osmfeatures.maphub.it/api/v1/features/admin-areas/geojson';
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $payload = $this->buildPayload();
+
+        try {
+            $response = Http::timeout(60)->withHeaders([
+                'accept' => 'application/json',
+                'Content-Type' => 'application/json',
+            ])->post($this->osmfeaturesApi, $payload);
+
+            if ($response->successful()) {
+                $this->addTaxonomyWheresToModel($response->json());
+            } else {
+                throw new \Exception("Failed to get taxonomy wheres for {$this->model->getTable()} {$this->model->id}. Status: {$response->status()}");
+            }
+        } catch (\Exception $e) {
+            $this->fail($e);
+        }
+    }
+
+    private function buildPayload()
+    {
+
+        $geojson = DB::table($this->model->getTable())
+            ->where('id', $this->model->id)
+            ->value(DB::raw('ST_AsGeoJSON(geometry)'));
+
+        if (!$geojson) {
+            throw new \Exception("No geometry found for {$modelTable} {$this->model->id}. Skipping...");
+        }
+
+        $feature = [
+            'type' => 'Feature',
+            'geometry' => json_decode($geojson, true),
+            'properties' => [
+                'name' => $this->model->properties['name'] ?? "{$this->model->getTable()} {$this->model->id}",
+            ],
+        ];
+
+        $payload = [
+            'geojson' => $feature,
+        ];
+
+        return $payload;
+    }
+
+    private function addTaxonomyWheresToModel($response)
+    {
+        $taxonomyWheresString = '';
+        foreach ($response['features'] as $feature) {
+            $taxonomyWhere = $feature['properties']['name'];
+            $taxonomyWheresString .= $taxonomyWhere . ', ';
+        }
+
+        //  Indirect modification of overloaded property ::$properties has no effect so i should extract the properties to a variable and then set the new value
+        $properties = $this->model->properties;
+        $properties['taxonomy_where'] = $taxonomyWheresString;
+        $this->model->properties = $properties;
+        $this->model->saveQuietly();
+    }
+}

--- a/app/Observers/HikingRouteObserver.php
+++ b/app/Observers/HikingRouteObserver.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Observers;
+
+use App\Jobs\ComputeTdhJob;
+use App\Jobs\GetTaxonomyWheresFromOsmfeaturesJob;
+use App\Jobs\SyncClubHikingRouteRelationJob;
+use App\Models\HikingRoute;
+
+class HikingRouteObserver
+{
+    /**
+     * Handle the HikingRoute "created" event.
+     *
+     * @param  \App\Models\HikingRoute  $hikingRoute
+     * @return void
+     */
+    public function created(HikingRoute $hikingRoute): void
+    {
+        SyncClubHikingRouteRelationJob::dispatch('HikingRoute', $hikingRoute->id);
+        GetTaxonomyWheresFromOsmfeaturesJob::dispatch($hikingRoute)->onQueue('geometric-computations');
+    }
+
+    /**
+     * Handle the HikingRoute "saving" event.
+     *
+     * @param  \App\Models\HikingRoute  $hikingRoute
+     * @return void
+     */
+    public function saving(HikingRoute $hikingRoute): void
+    {
+        if ($hikingRoute->isDirty('osmfeatures_data.properties.ref') && $hikingRoute->isDirty('osmfeatures_data.properties.from') && $hikingRoute->isDirty('osmfeatures_data.properties.to')) {
+            $hikingRoute->name = $hikingRoute->osmfeatures_data['properties']['ref'] . ' - ' . $hikingRoute->osmfeatures_data['properties']['from'] . ' - ' . $hikingRoute->osmfeatures_data['properties']['to'];
+            $hikingRoute->saveQuietly();
+        }
+
+        //todo: insert all properties 
+        if ($hikingRoute->isDirty('geometry')) {
+            // This logic was previously in the 'saved' event.
+            // Moved to 'saving' to ensure it runs before the 'updated' event logic.
+            if ($hikingRoute->exists) { // To mimic 'updated' event behavior
+                GetTaxonomyWheresFromOsmfeaturesJob::dispatch($hikingRoute)->onQueue('geometric-computations');
+                if ($hikingRoute->osm2cai_status == 4 && app()->environment('production')) {
+                    ComputeTdhJob::dispatch($hikingRoute->id);
+                }
+            }
+            $hikingRoute->dispatchGeometricComputationsJobs('geometric-computations');
+        }
+    }
+
+    /**
+     * Handle the HikingRoute "deleting" event.
+     *
+     * @param  \App\Models\HikingRoute  $hikingRoute
+     * @return void
+     */
+    public function deleting(HikingRoute $hikingRoute): void
+    {
+        $hikingRoute->cleanRelations();
+        $hikingRoute->clearMediaCollection('feature_image');
+    }
+}


### PR DESCRIPTION
This commit introduces two new console commands to enhance the functionality of the application:

- `osm2cai:get-taxonomy-wheres-from-osmfeatures`: This command fetches hiking routes with geometry and dispatches jobs to retrieve taxonomy data from the OSM features API.
- `osm2cai:populate-hiking-routes-properties`: This command populates the properties column of hiking routes with data extracted from `osmfeatures_data` for Elasticsearch indexing.

Additionally, a new job `GetTaxonomyWheresFromOsmfeaturesJob` is created to handle the API requests and process the taxonomy data for each hiking route. An observer for the `HikingRoute` model is also implemented to trigger the job upon creation and updates of hiking routes.