### PR TITLE
feat(metrics): ✨ add new UGC metrics for enhanced data visualization OC:5982

### DIFF
--- a/app/Nova/Metrics/UgcAppNameDistribution.php
+++ b/app/Nova/Metrics/UgcAppNameDistribution.php
@@ -2,7 +2,6 @@
 
 namespace App\Nova\Metrics;
 
-use App\Models\UgcPoi;
 use DateTimeInterface;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Metrics\Partition;
@@ -11,11 +10,26 @@ use Wm\WmPackage\Models\App;
 
 class UgcAppNameDistribution extends Partition
 {
+    /**
+     * Classe del modello da utilizzare
+     * @var string
+     */
+    protected string $modelClass;
+
+    /**
+     * Costruttore parametrico
+     */
+    public function __construct(string $modelClass)
+    {
+        parent::__construct();
+        $this->modelClass = $modelClass;
+    }
+
     public function calculate(NovaRequest $request): PartitionResult
     {
-        $data = UgcPoi::query()
-            ->selectRaw("COALESCE((properties->'app'->>'id'), 'null') as app_id, count(*) as count")
-            ->groupByRaw("COALESCE((properties->'app'->>'id'), 'null')")
+        $data = $this->modelClass::query()
+            ->selectRaw("COALESCE(app_id, 'null') as app_id, count(*) as count")
+            ->groupByRaw("COALESCE(app_id, 'null')")
             ->orderByDesc('count')
             ->get();
 

--- a/app/Nova/Metrics/UgcAppNameDistribution.php
+++ b/app/Nova/Metrics/UgcAppNameDistribution.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Nova\Metrics;
+
+use App\Models\UgcPoi;
+use DateTimeInterface;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Metrics\Partition;
+use Laravel\Nova\Metrics\PartitionResult;
+use Wm\WmPackage\Models\App;
+
+class UgcAppNameDistribution extends Partition
+{
+    public function calculate(NovaRequest $request): PartitionResult
+    {
+        $data = UgcPoi::query()
+            ->selectRaw("COALESCE((properties->'app'->>'id'), 'null') as app_id, count(*) as count")
+            ->groupByRaw("COALESCE((properties->'app'->>'id'), 'null')")
+            ->orderByDesc('count')
+            ->get();
+
+        $counts = $data->pluck('count', 'app_id')->toArray();
+
+        $result = [];
+        foreach ($counts as $appId => $count) {
+            if ($appId === 'null' || $appId === null || $appId === '') {
+                $name = 'Unknown';
+            } else {
+                $app = App::find($appId);
+                $name = $app ? ($app->name ?? $app->id) : $appId;
+            }
+            $result[$name] = $count;
+        }
+
+        $result = array_filter($result, fn($v) => $v > 0);
+        arsort($result);
+
+        return $this->result($result);
+    }
+
+    public function name()
+    {
+        return __('App Name');
+    }
+
+    public function cacheFor(): DateTimeInterface|null
+    {
+        return null;
+    }
+}

--- a/app/Nova/Metrics/UgcAppNameDistribution.php
+++ b/app/Nova/Metrics/UgcAppNameDistribution.php
@@ -27,8 +27,8 @@ class UgcAppNameDistribution extends Partition
     public function calculate(NovaRequest $request): PartitionResult
     {
         $data = $this->modelClass::query()
-            ->selectRaw("COALESCE(app_id, 'null') as app_id, count(*) as count")
-            ->groupByRaw("COALESCE(app_id, 'null')")
+            ->selectRaw('app_id, count(*) as count')
+            ->groupByRaw('app_id')
             ->orderByDesc('count')
             ->get();
 
@@ -36,11 +36,11 @@ class UgcAppNameDistribution extends Partition
 
         $result = [];
         foreach ($counts as $appId => $count) {
-            if ($appId === 'null' || $appId === null || $appId === '') {
-                $name = 'Unknown';
-            } else {
+            try {
                 $app = App::find($appId);
                 $name = $app ? ($app->name ?? $app->id) : $appId;
+            } catch (\Exception $e) {
+                $name = 'Unknown';
             }
             $result[$name] = $count;
         }

--- a/app/Nova/Metrics/UgcAppNameDistribution.php
+++ b/app/Nova/Metrics/UgcAppNameDistribution.php
@@ -12,7 +12,6 @@ class UgcAppNameDistribution extends Partition
 {
     /**
      * Classe del modello da utilizzare
-     * @var string
      */
     protected string $modelClass;
 
@@ -46,7 +45,7 @@ class UgcAppNameDistribution extends Partition
             $result[$name] = $count;
         }
 
-        $result = array_filter($result, fn($v) => $v > 0);
+        $result = array_filter($result, fn ($v) => $v > 0);
         arsort($result);
 
         return $this->result($result);
@@ -57,7 +56,7 @@ class UgcAppNameDistribution extends Partition
         return __('App Name');
     }
 
-    public function cacheFor(): DateTimeInterface|null
+    public function cacheFor(): ?DateTimeInterface
     {
         return null;
     }

--- a/app/Nova/Metrics/UgcAttributeDistribution.php
+++ b/app/Nova/Metrics/UgcAttributeDistribution.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Nova\Metrics;
+
+use App\Models\UgcPoi;
+use DateTimeInterface;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Metrics\Partition;
+use Laravel\Nova\Metrics\PartitionResult;
+
+class UgcAttributeDistribution extends Partition
+{
+    /**
+     * Etichetta visualizzata sulla metrica
+     * @var string
+     */
+    protected string $customLabel;
+
+    /**
+     * Path SQL dell'attributo da contare (es: properties->'device'->>'appVersion')
+     * @var string
+     */
+    protected string $path;
+
+    /**
+     * Costruttore parametrico
+     */
+    public function __construct(string $label = 'App Version Distribution', string $path = "properties->'device'->>'appVersion'")
+    {
+        parent::__construct();
+        $this->customLabel = $label;
+        $this->path = $path;
+    }
+
+    /**
+     * Calculate the value of the metric.
+     */
+    public function calculate(NovaRequest $request): PartitionResult
+    {
+        $data = UgcPoi::query()
+            ->selectRaw("{$this->path} as value, count(*) as count")
+            ->groupBy('value')
+            ->get()
+            ->pluck('count', 'value')
+            ->toArray();
+
+        // Sostituisco chiavi null o vuote con 'No Attribute'
+        $normalizedData = [];
+        foreach ($data as $key => $count) {
+            $label = (is_null($key) || $key === '' || $key === false) ? 'No Attribute' : $key;
+            if (isset($normalizedData[$label])) {
+                $normalizedData[$label] += $count;
+            } else {
+                $normalizedData[$label] = $count;
+            }
+        }
+
+        // Ordina per conteggio decrescente
+        arsort($normalizedData);
+
+        // Calcolo il totale per la percentuale
+        $total = array_sum($normalizedData);
+        $others = 0;
+        foreach ($normalizedData as $version => $count) {
+            $percent = $total > 0 ? ($count / $total) * 100 : 0;
+            if ($percent < 1) {
+                $others += $count;
+                unset($normalizedData[$version]);
+            }
+        }
+        if ($others > 0) {
+            $normalizedData['Others'] = $others;
+        }
+
+        return $this->result($normalizedData);
+    }
+
+    /**
+     * Determine the amount of time the results of the metric should be cached.
+     */
+    public function cacheFor(): DateTimeInterface|null
+    {
+        return null;
+    }
+
+    /**
+     * Get the name of the metric.
+     */
+    public function name()
+    {
+        return __($this->customLabel);
+    }
+}

--- a/app/Nova/Metrics/UgcAttributeDistribution.php
+++ b/app/Nova/Metrics/UgcAttributeDistribution.php
@@ -11,19 +11,16 @@ class UgcAttributeDistribution extends Partition
 {
     /**
      * Etichetta visualizzata sulla metrica
-     * @var string
      */
     protected string $customLabel;
 
     /**
      * Path SQL dell'attributo da contare (es: properties->'device'->>'appVersion')
-     * @var string
      */
     protected string $path;
 
     /**
      * Classe del modello da utilizzare
-     * @var string
      */
     protected string $modelClass;
 
@@ -84,7 +81,7 @@ class UgcAttributeDistribution extends Partition
     /**
      * Determine the amount of time the results of the metric should be cached.
      */
-    public function cacheFor(): DateTimeInterface|null
+    public function cacheFor(): ?DateTimeInterface
     {
         return null;
     }

--- a/app/Nova/Metrics/UgcAttributeDistribution.php
+++ b/app/Nova/Metrics/UgcAttributeDistribution.php
@@ -2,7 +2,6 @@
 
 namespace App\Nova\Metrics;
 
-use App\Models\UgcPoi;
 use DateTimeInterface;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Metrics\Partition;
@@ -23,13 +22,20 @@ class UgcAttributeDistribution extends Partition
     protected string $path;
 
     /**
+     * Classe del modello da utilizzare
+     * @var string
+     */
+    protected string $modelClass;
+
+    /**
      * Costruttore parametrico
      */
-    public function __construct(string $label = 'App Version Distribution', string $path = "properties->'device'->>'appVersion'")
+    public function __construct(string $label, string $path, string $modelClass)
     {
         parent::__construct();
         $this->customLabel = $label;
         $this->path = $path;
+        $this->modelClass = $modelClass;
     }
 
     /**
@@ -37,7 +43,7 @@ class UgcAttributeDistribution extends Partition
      */
     public function calculate(NovaRequest $request): PartitionResult
     {
-        $data = UgcPoi::query()
+        $data = $this->modelClass::query()
             ->selectRaw("{$this->path} as value, count(*) as count")
             ->groupBy('value')
             ->get()

--- a/app/Nova/Metrics/UgcDevicePlatformDistribution.php
+++ b/app/Nova/Metrics/UgcDevicePlatformDistribution.php
@@ -11,7 +11,6 @@ class UgcDevicePlatformDistribution extends Partition
 {
     /**
      * Classe del modello da utilizzare
-     * @var string
      */
     protected string $modelClass;
 
@@ -41,7 +40,7 @@ class UgcDevicePlatformDistribution extends Partition
         ];
 
         // Mostra solo le etichette con conteggio > 0
-        $result = array_filter($result, fn($v) => $v > 0);
+        $result = array_filter($result, fn ($v) => $v > 0);
 
         arsort($result);
 
@@ -53,7 +52,7 @@ class UgcDevicePlatformDistribution extends Partition
         return __('Device Platform');
     }
 
-    public function cacheFor(): DateTimeInterface|null
+    public function cacheFor(): ?DateTimeInterface
     {
         return null;
     }

--- a/app/Nova/Metrics/UgcDevicePlatformDistribution.php
+++ b/app/Nova/Metrics/UgcDevicePlatformDistribution.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Nova\Metrics;
+
+use App\Models\UgcPoi;
+use DateTimeInterface;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Metrics\Partition;
+use Laravel\Nova\Metrics\PartitionResult;
+
+class UgcDevicePlatformDistribution extends Partition
+{
+    public function calculate(NovaRequest $request): PartitionResult
+    {
+        $data = UgcPoi::query()
+            ->selectRaw("COALESCE(NULLIF(TRIM(properties->'device'->>'platform'), ''), 'null') as device_platform, count(*) as count")
+            ->groupBy('device_platform')
+            ->orderByDesc('count')
+            ->get()
+            ->pluck('count', 'device_platform')
+            ->toArray();
+
+        $result = [
+            '🍏 iOS' => $data['ios'] ?? 0,
+            '🤖 Android' => $data['android'] ?? 0,
+            '💻 Platform' => ($data['web'] ?? 0) + ($data['null'] ?? 0),
+        ];
+
+        // Mostra solo le etichette con conteggio > 0
+        $result = array_filter($result, fn($v) => $v > 0);
+
+        arsort($result);
+
+        return $this->result($result);
+    }
+
+    public function name()
+    {
+        return __('Device Platform');
+    }
+
+    public function cacheFor(): DateTimeInterface|null
+    {
+        return null;
+    }
+}

--- a/app/Nova/Metrics/UgcDevicePlatformDistribution.php
+++ b/app/Nova/Metrics/UgcDevicePlatformDistribution.php
@@ -2,7 +2,6 @@
 
 namespace App\Nova\Metrics;
 
-use App\Models\UgcPoi;
 use DateTimeInterface;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Metrics\Partition;
@@ -10,9 +9,24 @@ use Laravel\Nova\Metrics\PartitionResult;
 
 class UgcDevicePlatformDistribution extends Partition
 {
+    /**
+     * Classe del modello da utilizzare
+     * @var string
+     */
+    protected string $modelClass;
+
+    /**
+     * Costruttore parametrico
+     */
+    public function __construct(string $modelClass)
+    {
+        parent::__construct();
+        $this->modelClass = $modelClass;
+    }
+
     public function calculate(NovaRequest $request): PartitionResult
     {
-        $data = UgcPoi::query()
+        $data = $this->modelClass::query()
             ->selectRaw("COALESCE(NULLIF(TRIM(properties->'device'->>'platform'), ''), 'null') as device_platform, count(*) as count")
             ->groupBy('device_platform')
             ->orderByDesc('count')

--- a/app/Nova/Metrics/UgcValidatedStatusDistribution.php
+++ b/app/Nova/Metrics/UgcValidatedStatusDistribution.php
@@ -2,7 +2,6 @@
 
 namespace App\Nova\Metrics;
 
-use App\Models\UgcPoi;
 use App\Enums\ValidatedStatusEnum;
 use Illuminate\Support\Facades\DB;
 use Laravel\Nova\Http\Requests\NovaRequest;
@@ -10,10 +9,25 @@ use Laravel\Nova\Metrics\Partition;
 
 class UgcValidatedStatusDistribution extends Partition
 {
+    /**
+     * Classe del modello da utilizzare
+     * @var string
+     */
+    protected string $modelClass;
+
+    /**
+     * Costruttore parametrico
+     */
+    public function __construct(string $modelClass)
+    {
+        parent::__construct();
+        $this->modelClass = $modelClass;
+    }
+
     public function calculate(NovaRequest $request)
     {
         // Conta i POI per ogni stato di validazione
-        $data = UgcPoi::query()
+        $data = $this->modelClass::query()
             ->select('validated', DB::raw('count(*) as count'))
             ->groupBy('validated')
             ->pluck('count', 'validated')

--- a/app/Nova/Metrics/UgcValidatedStatusDistribution.php
+++ b/app/Nova/Metrics/UgcValidatedStatusDistribution.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Nova\Metrics;
+
+use App\Models\UgcPoi;
+use App\Enums\ValidatedStatusEnum;
+use Illuminate\Support\Facades\DB;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Metrics\Partition;
+
+class UgcValidatedStatusDistribution extends Partition
+{
+    public function calculate(NovaRequest $request)
+    {
+        // Conta i POI per ogni stato di validazione
+        $data = UgcPoi::query()
+            ->select('validated', DB::raw('count(*) as count'))
+            ->groupBy('validated')
+            ->pluck('count', 'validated')
+            ->toArray();
+        // Mappa value => label
+        $labels = [
+            ValidatedStatusEnum::VALID->value => __('Valid'),
+            ValidatedStatusEnum::INVALID->value => __('Invalid'),
+            ValidatedStatusEnum::NOT_VALIDATED->value => __('Not Validated'),
+        ];
+        // Mappa value => emoji
+        $emojis = [
+            ValidatedStatusEnum::VALID->value => '✅',
+            ValidatedStatusEnum::INVALID->value => '❌',
+            ValidatedStatusEnum::NOT_VALIDATED->value => '⏳',
+        ];
+        // Costruisce array emoji + label => count
+        $result = [];
+        foreach ($labels as $value => $label) {
+            $result[$emojis[$value] . ' ' . $label] = $data[$value] ?? 0;
+        }
+
+        return $this->result($result);
+    }
+
+    /**
+     * Get the URI key for the metric.
+     */
+    public function uriKey(): string
+    {
+        return 'ugc-validated-status-distribution';
+    }
+
+    /**
+     * Get the name of the metric.
+     */
+    public function name()
+    {
+        return __('Validated Status');
+    }
+}

--- a/app/Nova/Metrics/UgcValidatedStatusDistribution.php
+++ b/app/Nova/Metrics/UgcValidatedStatusDistribution.php
@@ -11,7 +11,6 @@ class UgcValidatedStatusDistribution extends Partition
 {
     /**
      * Classe del modello da utilizzare
-     * @var string
      */
     protected string $modelClass;
 
@@ -47,7 +46,7 @@ class UgcValidatedStatusDistribution extends Partition
         // Costruisce array emoji + label => count
         $result = [];
         foreach ($labels as $value => $label) {
-            $result[$emojis[$value] . ' ' . $label] = $data[$value] ?? 0;
+            $result[$emojis[$value].' '.$label] = $data[$value] ?? 0;
         }
 
         return $this->result($result);

--- a/app/Nova/UgcPoi.php
+++ b/app/Nova/UgcPoi.php
@@ -2,10 +2,6 @@
 
 namespace App\Nova;
 
-use App\Nova\Metrics\UgcAppNameDistribution;
-use App\Nova\Metrics\UgcDevicePlatformDistribution;
-use App\Nova\Metrics\UgcValidatedStatusDistribution;
-use App\Nova\Metrics\UgcAttributeDistribution;
 use App\Traits\Nova\UgcCommonFieldsTrait;
 use App\Traits\Nova\UgcCommonMethodsTrait;
 use Illuminate\Http\Request;
@@ -31,16 +27,6 @@ class UgcPoi extends WmUgcPoi
         return static::getResourceLabel('Poi');
     }
 
-    public function cards(Request $request): array
-    {
-        return [
-            new UgcAppNameDistribution,
-            new UgcAttributeDistribution('App Version', "properties->'device'->>'appVersion'"),
-            new UgcAttributeDistribution('App Form', "properties->'form'->>'id'"),
-            new UgcDevicePlatformDistribution,
-            new UgcValidatedStatusDistribution,
-        ];
-    }
     /**
      * Get the fields displayed by the resource.
      */
@@ -69,5 +55,13 @@ class UgcPoi extends WmUgcPoi
     protected function getPermissionType(): string
     {
         return 'pois';
+    }
+
+    /**
+     * Get the cards available for the request.
+     */
+    public function cards(Request $request): array
+    {
+        return $this->getCommonCards(static::$model);
     }
 }

--- a/app/Nova/UgcPoi.php
+++ b/app/Nova/UgcPoi.php
@@ -8,7 +8,6 @@ use Illuminate\Http\Request;
 use Wm\MapPoint\MapPoint;
 use Wm\WmPackage\Nova\UgcPoi as WmUgcPoi;
 
-
 class UgcPoi extends WmUgcPoi
 {
     use UgcCommonFieldsTrait, UgcCommonMethodsTrait;
@@ -19,6 +18,7 @@ class UgcPoi extends WmUgcPoi
      * @var string
      */
     public static $model = \App\Models\UgcPoi::class;
+
     /**
      * Get the resource label
      */

--- a/app/Nova/UgcPoi.php
+++ b/app/Nova/UgcPoi.php
@@ -2,11 +2,16 @@
 
 namespace App\Nova;
 
+use App\Nova\Metrics\UgcAppNameDistribution;
+use App\Nova\Metrics\UgcDevicePlatformDistribution;
+use App\Nova\Metrics\UgcValidatedStatusDistribution;
+use App\Nova\Metrics\UgcAttributeDistribution;
 use App\Traits\Nova\UgcCommonFieldsTrait;
 use App\Traits\Nova\UgcCommonMethodsTrait;
 use Illuminate\Http\Request;
 use Wm\MapPoint\MapPoint;
 use Wm\WmPackage\Nova\UgcPoi as WmUgcPoi;
+
 
 class UgcPoi extends WmUgcPoi
 {
@@ -18,7 +23,6 @@ class UgcPoi extends WmUgcPoi
      * @var string
      */
     public static $model = \App\Models\UgcPoi::class;
-
     /**
      * Get the resource label
      */
@@ -27,13 +31,23 @@ class UgcPoi extends WmUgcPoi
         return static::getResourceLabel('Poi');
     }
 
+    public function cards(Request $request): array
+    {
+        return [
+            new UgcAppNameDistribution,
+            new UgcAttributeDistribution('App Version', "properties->'device'->>'appVersion'"),
+            new UgcAttributeDistribution('App Form', "properties->'form'->>'id'"),
+            new UgcDevicePlatformDistribution,
+            new UgcValidatedStatusDistribution,
+        ];
+    }
     /**
      * Get the fields displayed by the resource.
      */
     public function fields(Request $request): array
     {
         $commonFields = $this->getCommonFields();
-        
+
         // Aggiungi MapPoint dopo tutti i campi comuni
         $commonFields[] = MapPoint::make('geometry')->withMeta([
             'center' => [43.7125, 10.4013],
@@ -45,7 +59,7 @@ class UgcPoi extends WmUgcPoi
             'defaultCenter' => [43.7125, 10.4013],
         ])->hideFromIndex()
             ->required();
-        
+
         return $commonFields;
     }
 

--- a/app/Nova/UgcTrack.php
+++ b/app/Nova/UgcTrack.php
@@ -30,8 +30,6 @@ class UgcTrack extends WmUgcTrack
 
     /**
      * Get the fields displayed by the resource.
-     *
-     * @return array
      */
     public function fields(Request $request): array
     {

--- a/app/Nova/UgcTrack.php
+++ b/app/Nova/UgcTrack.php
@@ -35,10 +35,10 @@ class UgcTrack extends WmUgcTrack
      */
     public function fields(Request $request): array
     {
-     $commonFields = $this->getCommonFields();
-     $commonFields = array_merge($commonFields, $this->additionalFields($request));
+        $commonFields = $this->getCommonFields();
+        $commonFields = array_merge($commonFields, $this->additionalFields($request));
 
-     return $commonFields;
+        return $commonFields;
     }
 
     /**
@@ -89,5 +89,13 @@ class UgcTrack extends WmUgcTrack
             'raw_data->latitude' => __('Latitudine'),
             'raw_data->longitude' => __('Longitudine'),
         ];
+    }
+
+    /**
+     * Get the cards available for the request.
+     */
+    public function cards(Request $request): array
+    {
+        return $this->getCommonCards(static::$model);
     }
 }

--- a/app/Traits/Nova/UgcCommonFieldsTrait.php
+++ b/app/Traits/Nova/UgcCommonFieldsTrait.php
@@ -15,6 +15,7 @@ use Carbon\Carbon;
 use Ebess\AdvancedNovaMediaLibrary\Fields\Images;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\ID;
@@ -22,7 +23,6 @@ use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
 use Wm\WmPackage\Nova\Actions\EditFields;
 use Wm\WmPackage\Nova\Fields\PropertiesPanel;
-use Illuminate\Support\Facades\Auth;
 
 trait UgcCommonFieldsTrait
 {
@@ -57,6 +57,7 @@ trait UgcCommonFieldsTrait
                     } elseif ($value === 'platform') {
                         return '<span style="font-size: 16px;">💻</span>';
                     }
+
                     return '<span style="font-size: 16px;">❓</span>';
                 })
                 ->asHtml()
@@ -85,10 +86,10 @@ trait UgcCommonFieldsTrait
                 ->hideWhenUpdating()
                 ->displayUsing(function ($value) {
                     return match ($value) {
-                        ValidatedStatusEnum::VALID->value => '<span title="' . __('Valid') . '">✅</span>',
-                        ValidatedStatusEnum::INVALID->value => '<span title="' . __('Invalid') . '">❌</span>',
-                        ValidatedStatusEnum::NOT_VALIDATED->value => '<span title="' . __('Not Validated') . '">⏳</span>',
-                        default => '<span title="' . ucfirst($value) . '">❓</span>',
+                        ValidatedStatusEnum::VALID->value => '<span title="'.__('Valid').'">✅</span>',
+                        ValidatedStatusEnum::INVALID->value => '<span title="'.__('Invalid').'">❌</span>',
+                        ValidatedStatusEnum::NOT_VALIDATED->value => '<span title="'.__('Not Validated').'">⏳</span>',
+                        default => '<span title="'.ucfirst($value).'">❓</span>',
                     };
                 })
                 ->asHtml(),
@@ -157,7 +158,7 @@ trait UgcCommonFieldsTrait
      */
     public function validatedStatusOptions(): array
     {
-        return Arr::mapWithKeys(ValidatedStatusEnum::cases(), fn($enum) => [$enum->value => $enum->name]);
+        return Arr::mapWithKeys(ValidatedStatusEnum::cases(), fn ($enum) => [$enum->value => $enum->name]);
     }
 
     /**


### PR DESCRIPTION
- Introduced the `UgcAppNameDistribution` metric to display the distribution of UGC app names.
- Added `UgcAttributeDistribution` for customizable attribute counting, with default paths for app version and form.
- Implemented `UgcDevicePlatformDistribution` to show platform distribution with emoji labels.
- Developed `UgcValidatedStatusDistribution` to visualize POI validation status using emojis.
- Updated `UgcPoi` Nova resource to include these new metrics in the `cards` method for better insights into UGC data.