### PR TITLE
feat(commands): ✨ add ConvertSuggestedToEcPois command oc:6292

### DIFF
--- a/app/Console/Commands/ConvertSuggestedToEcPois.php
+++ b/app/Console/Commands/ConvertSuggestedToEcPois.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\EcPoi;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\TaxonomyPoiType;
+use Wm\WmPackage\Services\GeometryComputationService;
+
+class ConvertSuggestedToEcPois extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:convert-suggested-to-ec-pois {--dry-run : Show what would be converted without actually doing it}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Convert suggested POIs to EcPois';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $isDryRun = $this->option('dry-run');
+
+        if ($isDryRun) {
+            $this->info('🔍 DRY RUN MODE - No changes will be made');
+        }
+
+        // Disabilita temporaneamente solo l'EcPoiObserver
+        $this->info('🔇 EcPoiObserver disabilitato durante la conversione');
+
+        // Trova l'app acquasorgente
+        $acquasorgenteApp = App::where('sku', 'it.webmapp.acquasorgente')->first();
+
+        if (! $acquasorgenteApp) {
+            $this->error('❌ App Acquasorgente non trovata!');
+
+            return 1;
+        }
+
+        $acquasorgenteAppId = $acquasorgenteApp->id;
+
+        $this->info('🚀 Starting conversion of suggested POIs to EcPois...');
+
+        // URL del GeoJSON dei suggeriti dell'App 58
+        $geojsonUrl = 'https://geohub.webmapp.it/api/export/taxonomy/geojson/58/overlay.geojson';
+
+        $this->info("📥 Fetching GeoJSON from: {$geojsonUrl}");
+
+        try {
+            $response = Http::timeout(60)->get($geojsonUrl);
+
+            if (! $response->successful()) {
+                $this->error("❌ Failed to fetch GeoJSON. HTTP Status: {$response->status()}");
+
+                return 1;
+            }
+
+            $geojsonData = $response->json();
+
+            if (! $geojsonData || ! isset($geojsonData['features'])) {
+                $this->error('❌ Invalid GeoJSON format or no features found');
+
+                return 1;
+            }
+
+            $featuresCount = count($geojsonData['features']);
+            $this->info("✅ Successfully fetched GeoJSON with {$featuresCount} features");
+
+            if ($isDryRun) {
+                $this->info('🔍 DRY RUN: Would process the following features:');
+                foreach (array_slice($geojsonData['features'], 0, 5) as $index => $feature) {
+                    $name = $feature['properties']['name'] ?? 'no name';
+                    $sourceRef = $feature['properties']['source_ref'] ?? 'no source ref';
+                    $this->line('   '.($index + 1).". {$name} (Source: {$sourceRef})");
+                }
+                if ($featuresCount > 5) {
+                    $this->line('   ... and '.($featuresCount - 5).' more features');
+                }
+            } else {
+                // TODO: chiamo save quietly e poi creo una custom chein di jobs
+                // Salva l'event dispatcher originale
+                $originalDispatcher = EcPoi::getEventDispatcher();
+
+                // Crea un nuovo dispatcher senza l'EcPoiObserver per non chiamare $app->buildPoisGeojson() ad ogni poi
+                $newDispatcher = new \Illuminate\Events\Dispatcher;
+                EcPoi::setEventDispatcher($newDispatcher);
+
+                $taxonomyPoiType = $this->createTaxonomyPoiTypeIfNotExists();
+
+                foreach ($geojsonData['features'] as $feature) {
+                    try {
+                        DB::beginTransaction();
+                        $properties = isset($feature['properties']) ? $feature['properties'] : [];
+                        $properties['suggestion'] = [
+                            'suggested_id' => $feature['properties']['id'],
+                            'conversion_date' => now()->toISOString(),
+                        ];
+                        // TODO: modificare la descricione con un html custom e migliorato
+                        $properties['description'] = isset($properties['popup']['html']) ? ['it' => $properties['popup']['html']] : [];
+
+                        $name = $properties['name'] ?? 'No name';
+
+                        // Converti la geometria GeoJSON in formato WKB
+                        $geometry = GeometryComputationService::make()->convertTo3DGeometry($feature['geometry']);
+
+                        $ecPoi = EcPoi::create([
+                            'name' => $name,
+                            'geometry' => $geometry,
+                            'properties' => $properties,
+                            'app_id' => $acquasorgenteAppId,
+                            'user_id' => $acquasorgenteApp->user_id,
+                            'type' => 'natural_spring',
+                            'score' => 1,
+                        ]);
+
+                        $ecPoi->taxonomyPoiTypes()->attach($taxonomyPoiType->id);
+
+                        DB::commit();
+
+                        $this->line("✅ Converted suggested POI ID {$feature['properties']['id']} to EcPoi ID {$ecPoi->id}");
+
+                        // Log dettagliato delle properties dell'EcPoi creato
+                        $this->line('📋 EcPoi Properties:');
+                        $this->line("   - ID: {$ecPoi->id}");
+                        $this->line("   - Name: {$ecPoi->name}");
+                        $this->line("   - Type: {$ecPoi->type}");
+                        $this->line("   - App ID: {$ecPoi->app_id}");
+                        $this->line("   - User ID: {$ecPoi->user_id}");
+                        $this->line("   - Score: {$ecPoi->score}");
+                        $this->line('   - Geometry: '.($ecPoi->geometry ? 'Present' : 'Missing'));
+                    } catch (\Exception $e) {
+                        DB::rollBack();
+                        $this->error('❌ Error converting suggested POIs: '.$e->getMessage());
+                        Log::error('Error converting suggested POIs', [
+                            'error' => $e->getMessage(),
+                        ]);
+                        // Ripristina l'event dispatcher originale
+                        EcPoi::setEventDispatcher($originalDispatcher);
+
+                        return 1;
+                    }
+                }
+            }
+        } catch (\Exception $e) {
+            $this->error('❌ Error fetching GeoJSON: '.$e->getMessage());
+            Log::error('Error fetching suggested POIs GeoJSON', [
+                'url' => $geojsonUrl,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+            // Ripristina l'event dispatcher originale
+            EcPoi::setEventDispatcher($originalDispatcher);
+
+            return 1;
+        }
+
+        $this->info('📊 Conversion Summary:');
+        $this->info('   - GeoJSON URL: '.$geojsonUrl);
+        $this->info('   - Features found: '.($featuresCount ?? 0));
+        $this->info('   - Mode: '.($isDryRun ? 'DRY RUN (no actual changes made)' : 'LIVE (changes applied)'));
+
+        $this->newLine();
+        $this->info('✅ Suggested POIs conversion completed!');
+
+        // Ripristina l'event dispatcher originale
+        EcPoi::setEventDispatcher($originalDispatcher);
+        $this->info('🔄 Event dispatcher ripristinato');
+
+        return 0;
+    }
+
+    public function createTaxonomyPoiTypeIfNotExists(): TaxonomyPoiType
+    {
+        $taxonomyPoiType = TaxonomyPoiType::where('identifier', 'water-suggestions')->first();
+        if (! $taxonomyPoiType) {
+            $taxonomyPoiType = TaxonomyPoiType::create([
+                'name' => ['it' => 'Suggerimenti', 'en' => 'Suggestions'],
+                'description' => [],
+                'excerpt' => [],
+                'identifier' => 'water-suggestions',
+                'icon' => 'txn-info',
+            ]);
+        }
+
+        return $taxonomyPoiType;
+    }
+}

--- a/app/Console/Commands/ConvertValidatedWaterUgcPoisToEcPois.php
+++ b/app/Console/Commands/ConvertValidatedWaterUgcPoisToEcPois.php
@@ -63,6 +63,14 @@ class ConvertValidatedWaterUgcPoisToEcPois extends Command
             return 0;
         }
 
+        // TODO: chiamo save quietly e poi creo una custom chein di jobs
+        // Salva l'event dispatcher originale
+        $originalDispatcher = EcPoi::getEventDispatcher();
+
+        // Crea un nuovo dispatcher senza l'EcPoiObserver per non chiamare $app->buildPoisGeojson() ad ogni poi
+        $newDispatcher = new \Illuminate\Events\Dispatcher;
+        EcPoi::setEventDispatcher($newDispatcher);
+
         $convertedCount = 0;
         $skippedCount = 0;
         $taxonomyPoiType = $this->createTaxonomyPoiTypeIfNotExists();
@@ -233,6 +241,9 @@ class ConvertValidatedWaterUgcPoisToEcPois extends Command
             $this->info('   - Mode: LIVE (changes applied)');
         }
 
+        // Ripristina l'event dispatcher originale
+        EcPoi::setEventDispatcher($originalDispatcher);
+
         return 0;
     }
 
@@ -241,14 +252,10 @@ class ConvertValidatedWaterUgcPoisToEcPois extends Command
         $taxonomyPoiType = TaxonomyPoiType::where('identifier', 'water-point')->first();
         if (! $taxonomyPoiType) {
             $taxonomyPoiType = TaxonomyPoiType::create([
-                'name' => ['it' => 'Punto acqua', 'en' => 'Water point'],
+                'name' => ['it' => 'Monitoraggio acqua', 'en' => 'Water monitoring'],
                 'description' => [],
                 'excerpt' => [],
-                'identifier' => 'water-point',
-                'properties' => [
-                    'name' => ['it' => 'Punto acqua'],
-                    'geohub_id' => 370,
-                ],
+                'identifier' => 'water-monitoring',
                 'icon' => 'txn-water',
             ]);
         }

--- a/scripts/wm-package-integration/scripts/setup-app58.sh
+++ b/scripts/wm-package-integration/scripts/setup-app58.sh
@@ -99,6 +99,14 @@ if ! docker exec "$PHP_CONTAINER" bash -c "cd /var/www/html/osm2cai2 && php arti
 fi
 print_success "Conversione UgcPois validati per App 58 completata"
 
+# Conversione suggeriti a EcPois
+print_step "Conversione suggeriti a EcPois..."
+if ! docker exec "$PHP_CONTAINER" bash -c "cd /var/www/html/osm2cai2 && php artisan app:convert-suggested-to-ec-pois"; then
+    print_error "Conversione suggeriti a EcPois fallita!"
+    exit 1
+fi
+print_success "Conversione suggeriti a EcPois completata"
+
 # Esempio di customizzazione (da personalizzare secondo le esigenze):
 print_step "Configurazione layer personalizzati per App 58..."
 # if ! ./scripts/02-create-layers-app58.sh; then
@@ -146,6 +154,11 @@ print_step "Verifica conversione UgcPois validati per App 58..."
 EC_POIS_COUNT=$(docker exec "$PHP_CONTAINER" bash -c "cd /var/www/html/osm2cai2 && php artisan tinker --execute=\"echo \App\Models\EcPoi::where('properties->ugc', true)->count();\"" 2>/dev/null || echo "0")
 print_success "EcPois convertiti da UgcPois: $EC_POIS_COUNT"
 
+# Verifica conversione suggeriti a EcPois
+print_step "Verifica conversione suggeriti a EcPois..."
+SUGGESTED_POIS_COUNT=$(docker exec "$PHP_CONTAINER" bash -c "cd /var/www/html/osm2cai2 && php artisan tinker --execute=\"echo \App\Models\EcPoi::where('properties->suggested', true)->count();\"" 2>/dev/null || echo "0")
+print_success "EcPois convertiti da suggeriti: $SUGGESTED_POIS_COUNT"
+
 # TODO: Aggiungere verifiche specifiche per le customizzazioni
 # LAYER_COUNT=$(docker exec "$PHP_CONTAINER" bash -c "cd /var/www/html/osm2cai2 && php artisan tinker --execute=\"echo \Wm\WmPackage\Models\Layer::where('app_id', \Wm\WmPackage\Models\App::where('geohub_id', 58)->first()->id)->count();\"" 2>/dev/null || echo "0")
 # print_success "Layer personalizzati per App 58: $LAYER_COUNT"
@@ -170,6 +183,7 @@ echo "📊 Statistiche App 58:"
 echo "   • App importata: ✅"
 echo "   • Hiking routes associate: $ROUTES_COUNT"
 echo "   • EcPois convertiti da UgcPois: $EC_POIS_COUNT"
+echo "   • EcPois convertiti da suggeriti: $SUGGESTED_POIS_COUNT"
 echo "   • Customizzazioni applicate: ✅"
 echo "   • Setup generico: ✅"
 echo "   • Code processate: ✅"


### PR DESCRIPTION
Introduce a new console command `ConvertSuggestedToEcPois` that converts suggested POIs to EcPois. The command can be run in dry-run mode to display what would be converted without making actual changes. The conversion process includes fetching GeoJSON data, processing features, and creating EcPoi entries with detailed logs and error handling.

Additionally, update the `ConvertValidatedWaterUgcPoisToEcPois` command to manage event dispatchers and modify taxonomy details for water-monitoring.

chore(scripts): 🔧 update setup script for EcPois conversion

Enhance the setup script `setup-app58.sh` to include steps for converting suggested POIs to EcPois. This includes executing the new artisan command, verifying the conversion, and updating the statistics section to reflect the new conversion process.

These updates ensure that the setup process includes the latest conversion functionalities and provides accurate feedback on the conversion status.
