### PR TITLE
refactor(commands): 🔧 improve POI naming logic oc:6305

### DIFF
--- a/app/Console/Commands/ConvertSuggestedToEcPois.php
+++ b/app/Console/Commands/ConvertSuggestedToEcPois.php
@@ -110,8 +110,8 @@ class ConvertSuggestedToEcPois extends Command
                         ];
                         // TODO: modificare la descricione con un html custom e migliorato
                         $properties['description'] = isset($properties['popup']['html']) ? ['it' => $properties['popup']['html']] : [];
-
-                        $name = $properties['name'] ?? 'No name';
+                        // name ec-poi costruito con ref e name del suggerito
+                        $name = $properties['name'] ? $properties['sent_ref'].' - '.$properties['name'] : $properties['sent_ref'];
 
                         // Converti la geometria GeoJSON in formato WKB
                         $geometry = GeometryComputationService::make()->convertTo3DGeometry($feature['geometry']);
@@ -131,7 +131,6 @@ class ConvertSuggestedToEcPois extends Command
                         DB::commit();
 
                         $this->line("✅ Converted suggested POI ID {$feature['properties']['id']} to EcPoi ID {$ecPoi->id}");
-
                     } catch (\Exception $e) {
                         DB::rollBack();
                         $this->error('❌ Error converting suggested POIs: '.$e->getMessage());

--- a/app/Console/Commands/ConvertValidatedWaterUgcPoisToEcPois.php
+++ b/app/Console/Commands/ConvertValidatedWaterUgcPoisToEcPois.php
@@ -120,9 +120,13 @@ class ConvertValidatedWaterUgcPoisToEcPois extends Command
                     unset($properties['uuid']);
                     $properties['form']['index'] = 0;
 
+                    // name preso da properties form
+                    $name = isset($properties['form']['title']) ? $properties['form']['title'] : $ugcPoi->name;
+                    $name = $name ?? 'Sorgente d\'acqua';
+
                     // Crea il nuovo EcPoi
                     $ecPoi = EcPoi::create([
-                        'name' => $ugcPoi->name ?? 'Sorgente d\'acqua',
+                        'name' => $name,
                         'geometry' => $ugcPoi->geometry,
                         'properties' => $properties,
                         'app_id' => $acquasorgenteAppId,


### PR DESCRIPTION
Updated the naming logic for POIs in the `ConvertSuggestedToEcPois` and `ConvertValidatedWaterUgcPoisToEcPois` commands.

In `ConvertSuggestedToEcPois`, the `name` is now constructed using the `ref` and `name` properties if available. In `ConvertValidatedWaterUgcPoisToEcPois`, the `name` is derived from `properties['form']['title']` or defaults to 'Sorgente d'acqua' if not available. Removed an unnecessary line break for better code readability.
