### PR TITLE
feat(app/Nova): 🌐 localize action names and messages OC:6313

### DIFF
--- a/app/Nova/Actions/AddRegionFavoritePublicationDateToHikingRouteAction.php
+++ b/app/Nova/Actions/AddRegionFavoritePublicationDateToHikingRouteAction.php
@@ -15,7 +15,7 @@ class AddRegionFavoritePublicationDateToHikingRouteAction extends Action
 
     public function __construct()
     {
-        $this->name = __('LOSCARPONE PUBLICATION DATE');
+        $this->name = __('Loscarpone Publication Date');
     }
 
     /**

--- a/app/Nova/Actions/BulkSectorsModeratorAssignAction.php
+++ b/app/Nova/Actions/BulkSectorsModeratorAssignAction.php
@@ -14,7 +14,12 @@ class BulkSectorsModeratorAssignAction extends Action
 {
     use InteractsWithQueue, Queueable;
 
-    public $name = 'Associa Referente Sentieristica';
+    public $name;
+
+    public function __construct()
+    {
+        $this->name = __('Associa Referente Sentieristica');
+    }
 
     /**
      * Perform the action on the given models.
@@ -30,7 +35,7 @@ class BulkSectorsModeratorAssignAction extends Action
             }
         });
 
-        return Action::message('Referenti Sentieristica assegnati correttamente!');
+        return Action::message(__('Referenti Sentieristica assegnati correttamente!'));
     }
 
     /**

--- a/app/Nova/Actions/CacheMiturApi.php
+++ b/app/Nova/Actions/CacheMiturApi.php
@@ -21,7 +21,7 @@ class CacheMiturApi extends Action
     public function __construct(string $class)
     {
         $this->class = $class;
-        $this->name = __('CACHE MITUR API');
+        $this->name = __('Cache Mitur API');
     }
 
     /**

--- a/app/Nova/Actions/CreateIssue.php
+++ b/app/Nova/Actions/CreateIssue.php
@@ -18,6 +18,8 @@ class CreateIssue extends Action
 {
     use InteractsWithQueue, Queueable;
 
+    public $name;
+
     public $model;
 
     public function __construct($model = null)
@@ -28,7 +30,7 @@ class CreateIssue extends Action
             $this->model = HikingRoute::find($resourceId);
         }
 
-        $this->name = __('ACCESSIBILITY ISSUE');
+        $this->name = __('Accessibility Issue');
     }
 
     /**

--- a/app/Nova/Actions/DeleteHikingRouteAction.php
+++ b/app/Nova/Actions/DeleteHikingRouteAction.php
@@ -16,7 +16,12 @@ class DeleteHikingRouteAction extends DestructiveAction
 
     public $onlyOnDetail = true;
 
-    public $name = 'DELETE';
+    public $name;
+
+    public function __construct()
+    {
+        $this->name = __('Delete');
+    }
 
     /**
      * Perform the action on the given models.

--- a/app/Nova/Actions/DeleteUgcMedia.php
+++ b/app/Nova/Actions/DeleteUgcMedia.php
@@ -14,6 +14,8 @@ class DeleteUgcMedia extends Action
 {
     use Queueable;
 
+    public $name;
+
     public $showOnDetail = true;
 
     public $showOnTableRow = true;

--- a/app/Nova/Actions/DownloadCsvCompleteAction.php
+++ b/app/Nova/Actions/DownloadCsvCompleteAction.php
@@ -13,9 +13,11 @@ class DownloadCsvCompleteAction extends Action
 {
     use InteractsWithQueue, Queueable;
 
+    public $name;
+
     public function __construct()
     {
-        $this->name = __('Download routes csv');
+        $this->name = __('Download routes CSV');
     }
 
     public $showOnDetail = true;

--- a/app/Nova/Actions/DownloadFeatureCollection.php
+++ b/app/Nova/Actions/DownloadFeatureCollection.php
@@ -13,7 +13,12 @@ class DownloadFeatureCollection extends Action
 {
     use InteractsWithQueue, Queueable;
 
-    public $name = 'Download GeoJSON';
+    public $name;
+
+    public function __construct()
+    {
+        $this->name = __('Download GeoJSON');
+    }
 
     /**
      * Perform the action on the given models.

--- a/app/Nova/Actions/DownloadGeojson.php
+++ b/app/Nova/Actions/DownloadGeojson.php
@@ -13,7 +13,7 @@ class DownloadGeojson extends Action
 {
     use InteractsWithQueue, Queueable;
 
-    public $name = 'Download GeoJSON';
+    public $name;
 
     public $showOnDetail = true;
 
@@ -22,6 +22,11 @@ class DownloadGeojson extends Action
     public $showOnTableRow = true;
 
     public $withoutConfirmation = true;
+
+    public function __construct()
+    {
+        $this->name = __('Download GeoJSON');
+    }
 
     /**
      * Perform the action on the given models.

--- a/app/Nova/Actions/DownloadGeojsonCompleteAction.php
+++ b/app/Nova/Actions/DownloadGeojsonCompleteAction.php
@@ -13,9 +13,11 @@ class DownloadGeojsonCompleteAction extends Action
 {
     use InteractsWithQueue, Queueable;
 
+    public $name;
+
     public function __construct()
     {
-        $this->name = __('Download routes geojson');
+        $this->name = __('Download routes GeoJSON');
     }
 
     public $showOnDetail = true;

--- a/app/Nova/Actions/DownloadGeojsonZip.php
+++ b/app/Nova/Actions/DownloadGeojsonZip.php
@@ -14,7 +14,12 @@ class DownloadGeojsonZip extends Action
 {
     use Queueable;
 
-    public $name = 'Download Geojson';
+    public $name;
+
+    public function __construct()
+    {
+        $this->name = __('Download Geojson');
+    }
 
     public function handle(ActionFields $fields, Collection $models)
     {

--- a/app/Nova/Actions/DownloadKml.php
+++ b/app/Nova/Actions/DownloadKml.php
@@ -13,7 +13,7 @@ class DownloadKml extends Action
 {
     use InteractsWithQueue, Queueable;
 
-    public $name = 'Download KML';
+    public $name;
 
     public $showOnDetail = true;
 
@@ -22,6 +22,11 @@ class DownloadKml extends Action
     public $showOnTableRow = true;
 
     public $withoutConfirmation = true;
+
+    public function __construct()
+    {
+        $this->name = __('Download KML');
+    }
 
     /**
      * Perform the action on the given models.

--- a/app/Nova/Actions/DownloadShape.php
+++ b/app/Nova/Actions/DownloadShape.php
@@ -13,7 +13,7 @@ class DownloadShape extends Action
 {
     use InteractsWithQueue, Queueable;
 
-    public $name = 'Download Shape';
+    public $name;
 
     public $showOnDetail = true;
 
@@ -22,6 +22,11 @@ class DownloadShape extends Action
     public $showOnTableRow = true;
 
     public $withoutConfirmation = true;
+
+    public function __construct()
+    {
+        $this->name = __('Download Shape');
+    }
 
     /**
      * Perform the action on the given models.

--- a/app/Nova/Actions/DownloadUgcCsv.php
+++ b/app/Nova/Actions/DownloadUgcCsv.php
@@ -15,7 +15,7 @@ class DownloadUgcCsv extends Action
 {
     use InteractsWithQueue, Queueable;
 
-    public $name = 'Download CSV';
+    public $name;
 
     public $showOnIndex = true;
 
@@ -26,6 +26,7 @@ class DownloadUgcCsv extends Action
     public function __construct($resourceClass)
     {
         $this->resourceClass = $resourceClass;
+        $this->name = __('Download CSV');
     }
 
     /**

--- a/app/Nova/Actions/FindClubHrAssociationAction.php
+++ b/app/Nova/Actions/FindClubHrAssociationAction.php
@@ -15,7 +15,12 @@ class FindClubHrAssociationAction extends Action
     use InteractsWithQueue;
     use Queueable;
 
-    public $name = 'Find Club Hiking Route Association';
+    public $name;
+
+    public function __construct()
+    {
+        $this->name = __('Find Club Hiking Route Association');
+    }
 
     /**
      * Indicates if this action can be run without any models.

--- a/app/Nova/Actions/ImportPois.php
+++ b/app/Nova/Actions/ImportPois.php
@@ -23,7 +23,7 @@ class ImportPois extends Action
     public function __construct($model = null)
     {
         $this->model = $model;
-        $this->name = __('IMPORT POIS');
+        $this->name = __('Import POIs');
 
         if (! is_null($resourceId = request('resourceId'))) {
             $this->model = HikingRoute::find($resourceId);

--- a/app/Nova/Actions/ManageHikingRouteValidationAction.php
+++ b/app/Nova/Actions/ManageHikingRouteValidationAction.php
@@ -20,7 +20,12 @@ class ManageHikingRouteValidationAction extends Action
 
     public $showOnDetail = true;
 
-    public $name = 'MANAGE VALIDATION';
+    public $name;
+
+    public function __construct()
+    {
+        $this->name = __('Manage Validation');
+    }
 
     /**
      * Perform the action on the given models.

--- a/app/Nova/Actions/OsmSyncHikingRouteAction.php
+++ b/app/Nova/Actions/OsmSyncHikingRouteAction.php
@@ -17,7 +17,12 @@ class OsmSyncHikingRouteAction extends Action
 
     public $showOnDetail = true;
 
-    public $name = 'SYNC WITH OSM DATA';
+    public $name;
+
+    public function __construct()
+    {
+        $this->name = __('Sync with OSM Data');
+    }
 
     /**
      * Perform the action on the given models.

--- a/app/Nova/Actions/OverpassMap.php
+++ b/app/Nova/Actions/OverpassMap.php
@@ -24,7 +24,7 @@ class OverpassMap extends Action
             $this->model = HikingRoute::find($resourceId);
         }
 
-        $this->name = __('SEARCH POINTS OF INTEREST');
+        $this->name = __('Search Points of Interest');
     }
 
     /**

--- a/app/Nova/Actions/PercorsoFavoritoAction.php
+++ b/app/Nova/Actions/PercorsoFavoritoAction.php
@@ -19,7 +19,7 @@ class PercorsoFavoritoAction extends Action
 
     public function __construct()
     {
-        $this->name = __('FAVORITE ROUTE');
+        $this->name = __('Favorite Route');
     }
 
     public function handle(ActionFields $fields, Collection $models)
@@ -27,13 +27,13 @@ class PercorsoFavoritoAction extends Action
         $user = auth()->user();
 
         if (! $user || $user == null) {
-            return Action::danger('User information not available');
+            return Action::danger(__('User information not available'));
         }
 
         $model = $models->first();
 
         if (! $user->canManageHikingRoute($model)) {
-            return Action::danger('You are not authorized for this hiking route');
+            return Action::danger(__('You are not authorized for this hiking route'));
         }
 
         // Handle FAVORITE toggle

--- a/app/Nova/Actions/RevertValidateHikingRouteAction.php
+++ b/app/Nova/Actions/RevertValidateHikingRouteAction.php
@@ -19,7 +19,7 @@ class RevertValidateHikingRouteAction extends Action
 
     public function __construct()
     {
-        $this->name = 'REVERT VALIDATION';
+        $this->name = __('Revert Validation');
     }
 
     /**
@@ -32,17 +32,17 @@ class RevertValidateHikingRouteAction extends Action
         $user = auth()->user();
 
         if (! $user || $user == null) {
-            return Action::danger('User information not available');
+            return Action::danger(__('User information not available'));
         }
 
         $model = $models->first();
 
         if ($model->osm2cai_status != 4) {
-            return Action::danger('The SDA is not 4!');
+            return Action::danger(__('The SDA is not 4!'));
         }
 
         if (! $user->canManageHikingRoute($model)) {
-            return Action::danger('You are not authorized to revert the validation of this hiking route');
+            return Action::danger(__('You are not authorized to revert the validation of this hiking route'));
         }
 
         $this->revertValidation($model);

--- a/app/Nova/Actions/SectorAssignModerator.php
+++ b/app/Nova/Actions/SectorAssignModerator.php
@@ -19,9 +19,11 @@ class SectorAssignModerator extends Action
 
     public $showOnIndex = false;
 
+    public $name;
+
     public function __construct()
     {
-        $this->name = __('Assign Moderator');
+        $this->name = __('Assign Sector Moderator');
     }
 
     /**

--- a/app/Nova/Actions/SectorRefactoring.php
+++ b/app/Nova/Actions/SectorRefactoring.php
@@ -18,7 +18,7 @@ class SectorRefactoring extends Action
 
     public function __construct()
     {
-        $this->name = __('SECTOR REFACTORING');
+        $this->name = __('Sector Refactoring');
     }
 
     /**

--- a/app/Nova/Actions/UploadAndAssociateUgcMedia.php
+++ b/app/Nova/Actions/UploadAndAssociateUgcMedia.php
@@ -20,6 +20,8 @@ class UploadAndAssociateUgcMedia extends Action
 
     public $showOnTableRow = true;
 
+    public $name;
+
     public function __construct()
     {
         $this->name = __('Upload Image');

--- a/app/Nova/Actions/UploadSectorGeometryAction.php
+++ b/app/Nova/Actions/UploadSectorGeometryAction.php
@@ -26,9 +26,11 @@ class UploadSectorGeometryAction extends Action
      * @param  Collection  $models
      * @return mixed
      */
+    public $name;
+
     public function __construct()
     {
-        $this->name = __('Aggiorna geometria');
+        $this->name = __('Update Geometry');
     }
 
     public function handle(ActionFields $fields, Collection $models)

--- a/app/Nova/Actions/UploadValidationRawDataAction.php
+++ b/app/Nova/Actions/UploadValidationRawDataAction.php
@@ -21,13 +21,14 @@ class UploadValidationRawDataAction extends Action
 
     public $showOnIndex = false;
 
-    public $name = 'UPLOAD GPX/KML/GEOJSON';
+    public $name;
 
     public $HR;
 
     public function __construct($HR = null)
     {
         $this->HR = HikingRoute::find($HR);
+        $this->name = __('Upload GPX/KML/GEOJSON');
     }
 
     /**

--- a/app/Nova/Actions/ValidateHikingRouteAction.php
+++ b/app/Nova/Actions/ValidateHikingRouteAction.php
@@ -21,7 +21,12 @@ class ValidateHikingRouteAction extends Action
 
     public $showOnIndex = false;
 
-    public $name = 'VALIDATE';
+    public $name;
+
+    public function __construct()
+    {
+        $this->name = __('Validate');
+    }
 
     /**
      * Perform the action on the given models.

--- a/app/Nova/Area.php
+++ b/app/Nova/Area.php
@@ -115,7 +115,7 @@ class Area extends Resource
                     ->width('1/4')
                     ->view('nova.cards.area-stats-card', [
                         'value' => implode(', ', $managers),
-                        'label' => 'Responsabili di settore',
+                        'label' => __('Sector Managers'),
                     ])
                     ->center()
                     ->withBasicStyles()
@@ -125,7 +125,7 @@ class Area extends Resource
                     ->width('1/4')
                     ->view('nova.cards.area-sal-card', [
                         'value' => number_format($sal * 100, 2),
-                        'label' => 'SAL',
+                        'label' => __('SAL'),
                         'backgroundColor' => Osm2caiHelper::getSalColor($sal),
                     ])
                     ->center()
@@ -136,7 +136,7 @@ class Area extends Resource
                     ->width('1/4')
                     ->view('nova.cards.area-stats-card', [
                         'value' => $tot[3] + $tot[4],
-                        'label' => 'Numero percorsi sda 3/4',
+                        'label' => __('Number of sda 3/4 routes'),
                     ])
                     ->center()
                     ->withBasicStyles()
@@ -146,7 +146,7 @@ class Area extends Resource
                     ->width('1/4')
                     ->view('nova.cards.area-stats-card', [
                         'value' => $area->num_expected,
-                        'label' => 'Numero percorsi attesi',
+                        'label' => __('Expected number of routes'),
                     ])
                     ->center()
                     ->withBasicStyles()

--- a/app/Nova/Dashboards/AcquaSorgente.php
+++ b/app/Nova/Dashboards/AcquaSorgente.php
@@ -16,7 +16,7 @@ class AcquaSorgente extends Dashboard
 
     public function label()
     {
-        return 'Riepilogo Acqua Sorgente';
+        return __('Acqua Sorgente Summary');
     }
 
     /**

--- a/app/Nova/Dashboards/Percorribilità.php
+++ b/app/Nova/Dashboards/Percorribilità.php
@@ -17,7 +17,7 @@ class Percorribilità extends Dashboard
 
     public function label()
     {
-        return 'Riepilogo Percorribilità';
+        return __('Riepilogo Percorribilità');
     }
 
     /**

--- a/app/Nova/Dashboards/PercorsiFavoriti.php
+++ b/app/Nova/Dashboards/PercorsiFavoriti.php
@@ -16,7 +16,7 @@ class PercorsiFavoriti extends Dashboard
 
     public function label()
     {
-        return 'Percorsi Favoriti';
+        return __('Percorsi Favoriti');
     }
 
     /**

--- a/app/Nova/Dashboards/SALMiturAbruzzo.php
+++ b/app/Nova/Dashboards/SALMiturAbruzzo.php
@@ -16,7 +16,7 @@ class SALMiturAbruzzo extends Dashboard
 
     public function label()
     {
-        return 'Riepilogo MITUR-Abruzzo';
+        return __('Riepilogo MITUR-Abruzzo');
     }
 
     /**

--- a/app/Nova/Dashboards/Utenti.php
+++ b/app/Nova/Dashboards/Utenti.php
@@ -16,7 +16,7 @@ class Utenti extends Dashboard
 
     public function label()
     {
-        return 'Riepilogo utenti';
+        return __('Riepilogo utenti');
     }
 
     /**

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -125,40 +125,40 @@ class User extends AbstractUserResource
         $baseFields = parent::fields($request);
 
         $relationFields = [
-            Text::make('Phone')
+            Text::make(__('Phone'))
                 ->sortable()
                 ->rules('max:255'),
 
-            BelongsToMany::make('Provinces', 'provinces', Province::class),
+            BelongsToMany::make(__('Provinces'), 'provinces', Province::class),
 
-            Text::make('Provinces', function () {
+            Text::make(__('Provinces'), function () {
                 return $this->provinces->pluck('name')->join(', ');
             })->onlyOnIndex(),
 
-            BelongsToMany::make('Areas', 'areas', Area::class),
+            BelongsToMany::make(__('Areas'), 'areas', Area::class),
 
-            Text::make('Areas', function () {
+            Text::make(__('Areas'), function () {
                 return $this->areas->pluck('name')->join(', ');
             })->onlyOnIndex(),
 
-            BelongsToMany::make('Sectors', 'sectors', Sector::class),
+            BelongsToMany::make(__('Sectors'), 'sectors', Sector::class),
 
-            Text::make('Sectors', function () {
+            Text::make(__('Sectors'), function () {
                 return $this->sectors->pluck('name')->join(', ');
             })->onlyOnIndex(),
 
-            BelongsTo::make('Region', 'region', NovaRegion::class)
+            BelongsTo::make(__('Region'), 'region', NovaRegion::class)
                 ->searchable()
                 ->nullable()
                 ->sortable(),
 
-            BelongsTo::make('Club Member', 'club', Club::class)
+            BelongsTo::make(__('Club Member'), 'club', Club::class)
                 ->searchable()
                 ->nullable()
                 ->sortable()
                 ->hideFromIndex(),
 
-            BelongsTo::make('Managed Club', 'managedClub', Club::class)
+            BelongsTo::make(__('Managed Club'), 'managedClub', Club::class)
                 ->searchable()
                 ->nullable()
                 ->sortable(),
@@ -184,8 +184,6 @@ class User extends AbstractUserResource
 
     /**
      * Get the filters available for the resource.
-     *
-     * @return array
      */
     public function filters(NovaRequest $request): array
     {


### PR DESCRIPTION
- Updated the names of actions and messages in the Nova actions classes to use localization functions (`__()`) for internationalization.
- Moved action name initializations into constructors where necessary to ensure proper assignment.
- Ensured consistency in the naming convention by using sentence case for action names.
- Applied localization to various labels and messages across multiple files to enhance multilingual support.
- Made changes in user-related fields to ensure localization compatibility.