### PR TITLE
refactor(nova): ♻️ localize geometry field labels OC:6340

### DIFF
--- a/app/Nova/CaiHut.php
+++ b/app/Nova/CaiHut.php
@@ -60,7 +60,7 @@ class CaiHut extends Resource
             Text::make(__('Owner')),
             Number::make(__('Elevation')),
             BelongsToField::make(__('Region')),
-            MapPoint::make(__('Geometry'))->withMeta([
+            MapPoint::make(__('Geometry'), 'geometry')->withMeta([
                 'center' => [42, 10],
                 'attribution' => '<a href="https://webmapp.it/">Webmapp</a> contributors',
                 'tiles' => 'https://api.webmapp.it/tiles/{z}/{x}/{y}.png',

--- a/app/Nova/HikingRoute.php
+++ b/app/Nova/HikingRoute.php
@@ -472,7 +472,7 @@ class HikingRoute extends OsmfeaturesResource
                     </ul>
                     HTML;
             })->asHtml()->onlyOnDetail(),
-            FeatureCollectionMap::make('geometry'),
+            FeatureCollectionMap::make(__('Geometry'), 'geometry'),
         ];
 
         return $fields;

--- a/app/Nova/Layer.php
+++ b/app/Nova/Layer.php
@@ -57,7 +57,7 @@ class Layer extends WmNovaLayer
                 ->searchable(),
             Images::make(__('Image'), 'default'),
             MorphToMany::make(__('Activities'), 'taxonomyActivities', TaxonomyActivity::class),
-            FeatureCollectionMap::make(__('geometry'))->onlyOnDetail(),
+            FeatureCollectionMap::make(__('Geometry'), 'geometry')->onlyOnDetail(),
             PropertiesPanel::makeWithModel(__('Properties'), 'properties', $this, true)->collapsible(),
             LayerFeatures::make(__('tracks'), $this->resource, HikingRoute::class)->hideWhenCreating()->withMeta(['model_class' => HikingRoute::class]),
         ];

--- a/app/Nova/MountainGroups.php
+++ b/app/Nova/MountainGroups.php
@@ -57,7 +57,7 @@ class MountainGroups extends Resource
             ID::make(__('ID'), 'id')->sortable(),
             Text::make(__('Name'), 'name')->sortable(),
             Textarea::make(__('Description'), 'description')->hideFromIndex(),
-            MapMultiPolygon::make(__('Geometry'))->withMeta([
+            MapMultiPolygon::make(__('Geometry'), 'geometry')->withMeta([
                 'center' => ['42.795977075', '10.326813853'],
                 'attribution' => '<a href="https://webmapp.it/">Webmapp</a> contributors',
             ])->hideFromIndex(),

--- a/app/Nova/OsmfeaturesResource.php
+++ b/app/Nova/OsmfeaturesResource.php
@@ -34,7 +34,7 @@ abstract class OsmfeaturesResource extends AbstractEcResource
         // if geometry type is point return MapPoint::make, if is multipolygon return MapMultiPolygon if is multilinestring return MapMultiLineString
         switch ($geometryType) {
             case 'Point':
-                $geometryField = MapPoint::make('geometry')->withMeta([
+                $geometryField = MapPoint::make(__('Geometry'), 'geometry')->withMeta([
                     'center' => [42, 10],
                     'attribution' => '<a href="https://webmapp.it/">Webmapp</a> contributors',
                     'tiles' => 'https://api.webmapp.it/tiles/{z}/{x}/{y}.png',
@@ -45,7 +45,7 @@ abstract class OsmfeaturesResource extends AbstractEcResource
                 ])->hideFromIndex();
                 break;
             case 'MultiPolygon':
-                $geometryField = MapMultiPolygon::make('Geometry')->withMeta([
+                $geometryField = MapMultiPolygon::make(__('Geometry'), 'geometry')->withMeta([
                     'center' => ['42.795977075', '10.326813853'],
                     'attribution' => '<a href="https://webmapp.it/">Webmapp</a> contributors',
                 ])->hideFromIndex();
@@ -53,7 +53,7 @@ abstract class OsmfeaturesResource extends AbstractEcResource
             default:
                 $centroid = $this->getCentroid();
                 $geojson = $this->getGeojsonForMapView();
-                $geometryField = Osm2caiMapMultiLinestring::make('geometry')->withMeta([
+                $geometryField = Osm2caiMapMultiLinestring::make(__('Geometry'), 'geometry')->withMeta([
                     'center' => $centroid ?? [42, 10],
                     'attribution' => '<a href="https://webmapp.it/">Webmapp</a> contributors',
                     'tiles' => 'https://api.webmapp.it/tiles/{z}/{x}/{y}.png',

--- a/app/Nova/Poles.php
+++ b/app/Nova/Poles.php
@@ -46,8 +46,8 @@ class Poles extends OsmfeaturesResource
             ->all();
 
         return array_merge($parentFields, [
-            Text::make('Ref', 'ref')->sortable(),
-            FeatureCollectionMap::make(__('geometry')),
+            Text::make(__('Ref'), 'ref')->sortable(),
+            FeatureCollectionMap::make(__('Geometry'), 'geometry'),
         ]);
     }
 }

--- a/app/Nova/Region.php
+++ b/app/Nova/Region.php
@@ -132,7 +132,7 @@ class Region extends Resource
                 return $stats['hiking_routes'][0] ?? 0;
             }),
 
-            MapMultiPolygon::make('Geometry')->withMeta([
+            MapMultiPolygon::make(__('Geometry'), 'geometry')->withMeta([
                 'center' => ['42.795977075', '10.326813853'],
                 'attribution' => '<a href="https://webmapp.it/">Webmapp</a> contributors',
             ])->hideFromIndex(),

--- a/app/Nova/Sector.php
+++ b/app/Nova/Sector.php
@@ -103,10 +103,10 @@ class Sector extends Resource
             BelongsToMany::make(__('Referenti Sentieristica'), 'moderators', User::class)
                 ->searchable(),
             BelongsTo::make(__('Area'))->onlyOnForms(),
-            File::make('Geometry')->store(function (Request $request, $model) {
+            File::make(__('Geometry'), 'geometry')->store(function (Request $request, $model) {
                 return $model->fileToGeometry($request->geometry->get());
             })->onlyOnForms()->hideWhenUpdating()->required(),
-            MapMultiPolygon::make('geometry')->withMeta([
+            MapMultiPolygon::make(__('Geometry'), 'geometry')->withMeta([
                 'center' => ['42.795977075', '10.326813853'],
                 'attribution' => '<a href="https://webmapp.it/">Webmapp</a> contributors',
             ])->onlyOnDetail(),


### PR DESCRIPTION
- Updated various Nova resources to ensure the 'Geometry' field labels are localized using the `__()` function.
- Added a second parameter to `MapPoint`, `FeatureCollectionMap`, `MapMultiPolygon`, `Osm2caiMapMultiLinestring`, and `File` to explicitly specify the field name.
- Improved consistency and clarity across the application by ensuring all geometry-related fields are properly localized and labeled.