### PR TITLE
feat(auth): ✨ implement authorization methods for Club resource management oc: 6723

### DIFF
--- a/app/Nova/Club.php
+++ b/app/Nova/Club.php
@@ -28,6 +28,7 @@ use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Nova;
+use Wm\MapPoint\MapPoint;
 
 class Club extends Resource
 {
@@ -130,6 +131,15 @@ class Club extends Resource
                 return $this->formatUserList($this->users()->get(), null, true);
             })->asHtml()
                 ->onlyOnDetail(),
+            MapPoint::make(__('Geometry'), 'geometry')->withMeta([
+                'center' => [43.7125, 10.4013],
+                'attribution' => '<a href="https://webmapp.it/">Webmapp</a> contributors',
+                'tiles' => 'https://api.webmapp.it/tiles/{z}/{x}/{y}.png',
+                'minZoom' => 8,
+                'maxZoom' => 14,
+                'defaultZoom' => 10,
+                'defaultCenter' => [43.7125, 10.4013],
+            ])->hideFromIndex(),
             BelongsToMany::make(__('Club\'s hiking routes'), 'hikingRoutes', HikingRoute::class)
                 ->help(__('Only national referents can add hiking routes to the club')),
             Text::make(__('SDA1'), function () use ($hikingRoutesSDA1) {

--- a/app/Nova/Club.php
+++ b/app/Nova/Club.php
@@ -389,6 +389,28 @@ class Club extends Resource
      */
     public static function authorizedToCreate($request)
     {
-        return false;
+        $user = $request->user();
+
+        return $user && $user->hasRole(UserRole::Administrator);
+    }
+
+    /**
+     * Determine if the current user can update the given resource.
+     */
+    public function authorizedToUpdate(Request $request)
+    {
+        $user = $request->user();
+
+        return $user && $user->hasRole(UserRole::Administrator);
+    }
+
+    /**
+     * Determine if the current user can delete the given resource.
+     */
+    public function authorizedToDelete(Request $request)
+    {
+        $user = $request->user();
+
+        return $user && $user->hasRole(UserRole::Administrator);
     }
 }

--- a/app/Policies/ClubPolicy.php
+++ b/app/Policies/ClubPolicy.php
@@ -37,7 +37,7 @@ class ClubPolicy
      */
     public function update(User $user, Club $club): bool
     {
-        return false;
+        return $user->hasRole(UserRole::Administrator);
     }
 
     /**
@@ -45,7 +45,7 @@ class ClubPolicy
      */
     public function delete(User $user, Club $club): bool
     {
-        return false;
+        return $user->hasRole(UserRole::Administrator);
     }
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -16,6 +16,7 @@ class AuthServiceProvider extends ServiceProvider
         // 'App\Models\Model' => 'App\Policies\ModelPolicy',
         \App\Models\HikingRoute::class => \App\Policies\HikingRoutePolicy::class,
         \App\Models\TrailSurvey::class => \App\Policies\TrailSurveyPolicy::class,
+        \App\Models\Club::class => \App\Policies\ClubPolicy::class,
         \Wm\WmPackage\Models\TaxonomyPoiType::class => \Wm\WmPackage\Policies\TaxonomyPoiTypePolicy::class,
         \Wm\WmPackage\Models\TaxonomyActivity::class => \Wm\WmPackage\Policies\TaxonomyActivityPolicy::class,
     ];


### PR DESCRIPTION
- Added methods to `Club` class for checking user permissions to create, update, and delete resources based on the Administrator role.
- Updated `ClubPolicy` to reflect the new authorization logic for create, update, and delete actions, ensuring only users with the Administrator role can perform these actions.
- Registered `ClubPolicy` in `AuthServiceProvider` to enforce the new authorization rules across the application.
