### PR TITLE
feat(UgcCommonModelTrait): ✨ add geometry synchronization to UGC properties OC:6698

### DIFF
--- a/app/Services/GeometryService.php
+++ b/app/Services/GeometryService.php
@@ -150,7 +150,7 @@ class GeometryService
             return null;
         }
 
-        $geometry = GeometryComputationService::make()->geojsonToGeometry($geometry);
+        $geometry = $this->geojsonToGeometry($geometry);
 
         return DB::select("select ST_AsGeoJSON(ST_Centroid('".$geometry."')) as g")[0]->g;
     }

--- a/app/Services/GeometryService.php
+++ b/app/Services/GeometryService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use Illuminate\Support\Facades\DB;
 use Symm\Gisconverter\Exceptions\InvalidText;
 use Symm\Gisconverter\Gisconverter;
+use Wm\WmPackage\Services\GeometryComputationService;
 
 class GeometryService
 {
@@ -20,15 +21,7 @@ class GeometryService
 
     public function geojsonToGeometry($geojson)
     {
-        if (empty($geojson)) {
-            return null;
-        }
-
-        if (is_array($geojson)) {
-            $geojson = json_encode($geojson);
-        }
-
-        return DB::select("select (ST_Force3D(ST_GeomFromGeoJSON('".$geojson."'))) as g ")[0]->g;
+        return GeometryComputationService::make()->geojsonToGeometry($geojson);
     }
 
     /**
@@ -157,7 +150,7 @@ class GeometryService
             return null;
         }
 
-        $geometry = $this->geojsonToGeometry($geometry);
+        $geometry = GeometryComputationService::make()->geojsonToGeometry($geometry);
 
         return DB::select("select ST_AsGeoJSON(ST_Centroid('".$geometry."')) as g")[0]->g;
     }

--- a/app/Traits/UgcCommonModelTrait.php
+++ b/app/Traits/UgcCommonModelTrait.php
@@ -105,7 +105,7 @@ trait UgcCommonModelTrait
             }
 
             // Controlla se il campo validated è stato cambiato a VALID
-            if ($ugc->wasChanged('validated') && $ugc->validated === ValidatedStatusEnum::VALID->value) {
+            if ($ugc->isDirty('validated') && $ugc->validated === ValidatedStatusEnum::VALID->value) {
                 $ugc->createEcPoiFromValidatedUgc();
             }
         });

--- a/app/Traits/UgcCommonModelTrait.php
+++ b/app/Traits/UgcCommonModelTrait.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Wm\WmPackage\Models\App;
 use Wm\WmPackage\Models\TaxonomyPoiType;
+use Wm\WmPackage\Services\GeometryComputationService;
 
 trait UgcCommonModelTrait
 {
@@ -69,13 +70,107 @@ trait UgcCommonModelTrait
             }
         });
 
-        // Quando si salva un UGC, controlla se è stato validato
+        // Quando si salva un UGC, sincronizza geometry in properties.position e controlla se è stato validato
         static::saved(function ($ugc) {
+            // Sincronizza geometry in properties.position in base al tipo di geometria
+            if ($ugc->geometry !== null && $ugc->id) {
+                try {
+                    $table = $ugc->getTable();
+
+                    // Leggi properties dal database per avere i valori aggiornati
+                    $currentProperties = DB::table($table)
+                        ->where('id', $ugc->id)
+                        ->value('properties');
+
+                    $properties = is_string($currentProperties)
+                        ? json_decode($currentProperties, true) ?? []
+                        : ($currentProperties ?? []);
+
+                    // Estrai latitude e longitude usando GeometryComputationService del wm-package
+                    $coordinates = self::extractCoordinatesFromUgcModel($ugc);
+
+                    // Salva solo latitude e longitude in properties.position
+                    if ($coordinates !== null) {
+                        $currentLat = $properties['position']['latitude'] ?? null;
+                        $currentLon = $properties['position']['longitude'] ?? null;
+
+                        // Aggiorna solo se le coordinate sono cambiate o non esistono
+                        if ($currentLat !== $coordinates['latitude'] || $currentLon !== $coordinates['longitude']) {
+                            $properties['position'] = [
+                                'latitude' => $coordinates['latitude'],
+                                'longitude' => $coordinates['longitude'],
+                            ];
+
+                            // Aggiorna properties senza triggerare altri observer per evitare loop
+                            DB::table($table)
+                                ->where('id', $ugc->id)
+                                ->update(['properties' => json_encode($properties)]);
+
+                            // Aggiorna anche l'attributo del modello per mantenere la sincronizzazione
+                            $ugc->setAttribute('properties', $properties);
+                        }
+                    }
+                } catch (\Exception $e) {
+                    Log::warning('Errore nel sincronizzare geometry in properties.position durante saved', [
+                        'model_id' => $ugc->id,
+                        'model_type' => get_class($ugc),
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
+
             // Controlla se il campo validated è stato cambiato a VALID
-            if ($ugc->isDirty('validated') && $ugc->validated === ValidatedStatusEnum::VALID->value) {
+            if ($ugc->wasChanged('validated') && $ugc->validated === ValidatedStatusEnum::VALID->value) {
                 $ugc->createEcPoiFromValidatedUgc();
             }
         });
+    }
+
+    /**
+     * Estrae latitude e longitude da geometry del modello UGC
+     * Usa il valore di geometry direttamente dal modello (non dal database)
+     * Gestisce solo Point (per POI), le tracce non vengono sincronizzate
+     *
+     * @param  mixed  $ugc  Modello UGC (UgcPoi, UgcTrack, ecc.)
+     * @return array|null Array con 'latitude' e 'longitude' o null se non disponibile
+     */
+    private static function extractCoordinatesFromUgcModel($ugc): ?array
+    {
+        if (empty($ugc->geometry)) {
+            return null;
+        }
+
+        // Converti geometry in GeoJSON usando il metodo del package
+        $geojsonString = GeometryComputationService::make()->getModelGeometryAsGeojson($ugc);
+
+        if (! $geojsonString) {
+            return null;
+        }
+
+        $geometryArray = json_decode($geojsonString, true);
+
+        if (! $geometryArray || ! isset($geometryArray['type']) || ! isset($geometryArray['coordinates'])) {
+            return null;
+        }
+
+        $coords = $geometryArray['coordinates'];
+        $latitude = null;
+        $longitude = null;
+
+        // Per Point: coordinates è [longitude, latitude]
+        if ($geometryArray['type'] === 'Point' && is_array($coords) && count($coords) >= 2) {
+            $longitude = (float) $coords[0];
+            $latitude = (float) $coords[1];
+        }
+
+        if ($latitude !== null && $longitude !== null) {
+            return [
+                'latitude' => $latitude,
+                'longitude' => $longitude,
+            ];
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
- Introduced a new feature to synchronize geometry data into properties.position within UGC models during the saved event.
- Implemented a method to extract latitude and longitude from the UGC model's geometry using GeometryComputationService.
- Updated properties in the database only if the geographical coordinates have changed.
- Added error handling to log any exceptions encountered during the synchronization process.
- Modified the condition to check for changes in the validated field using wasChanged instead of isDirty for accuracy.
