### PR TITLE
refactor(filters): ♻️ refactor filters to improve code reuse and maintainability OC:7206

### DIFF
--- a/app/Nova/Filters/AreaFilter.php
+++ b/app/Nova/Filters/AreaFilter.php
@@ -4,33 +4,57 @@ namespace App\Nova\Filters;
 
 use App\Enums\UserRole;
 use App\Models\Area;
-use Illuminate\Http\Request;
-use Laravel\Nova\Filters\Filter;
+use Laravel\Nova\Http\Requests\NovaRequest;
 
-class AreaFilter extends Filter
+class AreaFilter extends BaseOSMFeaturesFilter
 {
-    /**
-     * The filter's component.
-     *
-     * @var string
-     */
-    public $component = 'select-filter';
-
-    public $name;
-
     public function __construct()
     {
-        $this->name = __('Area');
+        parent::__construct(__('Area'));
     }
 
-    /**
-     * Apply the filter to the given query.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  mixed  $value
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function apply(Request $request, $query, $value)
+    protected function getEmptyOptionLabel(): string
+    {
+        return __('No area');
+    }
+
+    protected function getEmptyOptionValue(): string
+    {
+        return 'no_area';
+    }
+
+    protected function getEntityOptions(NovaRequest $request): array
+    {
+        $options = [];
+        $user = $request->user();
+        if ($user && $user->hasRole(UserRole::RegionalReferent)) {
+            $areas = Area::whereIn('province_id', $user->region->provinces->pluck('id')->toArray())->orderBy('name')->get();
+            foreach ($areas as $item) {
+                $options[$item->name] = $item->id;
+            }
+        } else {
+            foreach (Area::orderBy('name')->get() as $item) {
+                $options[$item->name] = $item->id;
+            }
+        }
+
+        return $options;
+    }
+
+    protected function applyEmpty(NovaRequest $request, $query)
+    {
+        if ($query->getModel() instanceof \App\Models\HikingRoute) {
+            return $query->whereDoesntHave('areas');
+        }
+
+        if ($query->getModel() instanceof \App\Models\User) {
+            return $query->whereDoesntHave('areas');
+        }
+
+        return $query->whereNull('area_id');
+    }
+
+    protected function applyValue(NovaRequest $request, $query, $value)
     {
         if ($query->getModel() instanceof \App\Models\HikingRoute) {
             return $query->whereHas('areas', function ($query) use ($value) {
@@ -45,27 +69,5 @@ class AreaFilter extends Filter
         }
 
         return $query->where('area_id', $value);
-    }
-
-    /**
-     * Get the filter's available options.
-     *
-     * @return array
-     */
-    public function options(Request $request)
-    {
-        $options = [];
-        if (auth()->user()->hasRole(UserRole::RegionalReferent)) {
-            $areas = Area::whereIn('province_id', auth()->user()->region->provinces->pluck('id')->toArray())->orderBy('name')->get();
-            foreach ($areas as $item) {
-                $options[$item->name] = $item->id;
-            }
-        } else {
-            foreach (Area::orderBy('name')->get() as $item) {
-                $options[$item->name] = $item->id;
-            }
-        }
-
-        return $options;
     }
 }

--- a/app/Nova/Filters/BaseOSMFeaturesFilter.php
+++ b/app/Nova/Filters/BaseOSMFeaturesFilter.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Nova\Filters;
+
+use Laravel\Nova\Filters\Filter;
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+abstract class BaseOSMFeaturesFilter extends Filter
+{
+    /**
+     * The filter's component.
+     *
+     * @var string
+     */
+    public $component = 'select-filter';
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Apply the filter to the given query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply(NovaRequest $request, $query, $value)
+    {
+        if ($value === $this->getEmptyOptionValue()) {
+            return $this->applyEmpty($request, $query);
+        }
+
+        return $this->applyValue($request, $query, $value);
+    }
+
+    /**
+     * Get the filter's available options.
+     *
+     * @return array
+     */
+    public function options(NovaRequest $request)
+    {
+        return [
+            $this->getEmptyOptionLabel() => $this->getEmptyOptionValue(),
+        ] + $this->getEntityOptions($request);
+    }
+
+    /**
+     * Label for the "empty" option (e.g. "Senza regione").
+     */
+    abstract protected function getEmptyOptionLabel(): string;
+
+    /**
+     * Value for the "empty" option (e.g. "no_region").
+     */
+    abstract protected function getEmptyOptionValue(): string;
+
+    /**
+     * Entity options for the select (label => value).
+     *
+     * @return array<string, mixed>
+     */
+    abstract protected function getEntityOptions(NovaRequest $request): array;
+
+    /**
+     * Apply filter for records without the attribute set.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    abstract protected function applyEmpty(NovaRequest $request, $query);
+
+    /**
+     * Apply filter for a specific attribute value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    abstract protected function applyValue(NovaRequest $request, $query, $value);
+}

--- a/app/Nova/Filters/ProvinceFilter.php
+++ b/app/Nova/Filters/ProvinceFilter.php
@@ -4,33 +4,57 @@ namespace App\Nova\Filters;
 
 use App\Enums\UserRole;
 use App\Models\Province;
-use Illuminate\Http\Request;
-use Laravel\Nova\Filters\Filter;
+use Laravel\Nova\Http\Requests\NovaRequest;
 
-class ProvinceFilter extends Filter
+class ProvinceFilter extends BaseOSMFeaturesFilter
 {
-    /**
-     * The filter's component.
-     *
-     * @var string
-     */
-    public $component = 'select-filter';
-
-    public $name;
-
     public function __construct()
     {
-        $this->name = __('Province');
+        parent::__construct(__('Province'));
     }
 
-    /**
-     * Apply the filter to the given query.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  mixed  $value
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function apply(Request $request, $query, $value)
+    protected function getEmptyOptionLabel(): string
+    {
+        return __('No province');
+    }
+
+    protected function getEmptyOptionValue(): string
+    {
+        return 'no_province';
+    }
+
+    protected function getEntityOptions(NovaRequest $request): array
+    {
+        $options = [];
+        $user = $request->user();
+        if ($user && $user->hasRole(UserRole::RegionalReferent)) {
+            $provinces = Province::where('region_id', $user->region->id)->orderBy('name')->get();
+            foreach ($provinces as $item) {
+                $options[$item->name] = $item->id;
+            }
+        } else {
+            foreach (Province::orderBy('name')->get() as $item) {
+                $options[$item->name] = $item->id;
+            }
+        }
+
+        return $options;
+    }
+
+    protected function applyEmpty(NovaRequest $request, $query)
+    {
+        if ($query->getModel() instanceof \App\Models\HikingRoute) {
+            return $query->whereDoesntHave('provinces');
+        }
+
+        if ($query->getModel() instanceof \App\Models\User) {
+            return $query->whereDoesntHave('provinces');
+        }
+
+        return $query->whereNull('province_id');
+    }
+
+    protected function applyValue(NovaRequest $request, $query, $value)
     {
         if ($query->getModel() instanceof \App\Models\HikingRoute) {
             return $query->whereHas('provinces', function ($query) use ($value) {
@@ -45,27 +69,5 @@ class ProvinceFilter extends Filter
         }
 
         return $query->where('province_id', $value);
-    }
-
-    /**
-     * Get the filter's available options.
-     *
-     * @return array
-     */
-    public function options(Request $request)
-    {
-        $options = [];
-        if (auth()->user()->hasRole(UserRole::RegionalReferent)) {
-            $provinces = Province::where('region_id', auth()->user()->region->id)->orderBy('name')->get();
-            foreach ($provinces as $item) {
-                $options[$item->name] = $item->id;
-            }
-        } else {
-            foreach (Province::orderBy('name')->get() as $item) {
-                $options[$item->name] = $item->id;
-            }
-        }
-
-        return $options;
     }
 }

--- a/app/Nova/Filters/RegionFilter.php
+++ b/app/Nova/Filters/RegionFilter.php
@@ -7,50 +7,56 @@ use App\Models\Province;
 use App\Models\Region;
 use App\Models\Sector;
 use App\Models\User;
-use Laravel\Nova\Filters\Filter;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
-class RegionFilter extends Filter
+class RegionFilter extends BaseOSMFeaturesFilter
 {
-    /**
-     * The filter's component.
-     *
-     * @var string
-     */
-    public $component = 'select-filter';
-
     public function __construct()
     {
-        $this->name = __('Region');
+        parent::__construct(__('Region'));
     }
 
-    /**
-     * Apply the filter to the given query.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  mixed  $value
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function apply(NovaRequest $request, $query, $value)
+    protected function getEmptyOptionLabel(): string
+    {
+        return __('No region');
+    }
+
+    protected function getEmptyOptionValue(): string
+    {
+        return 'no_region';
+    }
+
+    protected function getEntityOptions(NovaRequest $request): array
+    {
+        $options = [];
+        foreach (Region::all() as $region) {
+            $options[$region->name] = $region->id;
+        }
+
+        return $options;
+    }
+
+    protected function applyEmpty(NovaRequest $request, $query)
     {
         $model = $query->getModel();
 
-        // Gestione del caso "senza regione"
-        if ($value === 'no_region') {
-            if ($model instanceof Province || $model instanceof Club || $model instanceof User) {
-                return $query->whereNull('region_id');
-            }
-
-            if ($model instanceof Sector) {
-                return $query->whereHas('area.province', function ($query) {
-                    $query->whereNull('region_id');
-                });
-            }
-
-            return $query->whereDoesntHave('regions');
+        if ($model instanceof Province || $model instanceof Club || $model instanceof User) {
+            return $query->whereNull('region_id');
         }
 
-        // Gestione normale con regione specifica
+        if ($model instanceof Sector) {
+            return $query->whereHas('area.province', function ($query) {
+                $query->whereNull('region_id');
+            });
+        }
+
+        return $query->whereDoesntHave('regions');
+    }
+
+    protected function applyValue(NovaRequest $request, $query, $value)
+    {
+        $model = $query->getModel();
+
         if ($model instanceof Province || $model instanceof Club) {
             return $query->where('region_id', $value);
         }
@@ -70,25 +76,5 @@ class RegionFilter extends Filter
         return $query->whereHas('regions', function ($query) use ($value) {
             $query->where('region_id', $value);
         });
-    }
-
-    /**
-     * Get the filter's available options.
-     *
-     * @return array
-     */
-    public function options(NovaRequest $request)
-    {
-        $options = [];
-
-        // Aggiungi l'opzione "Senza regione" come prima opzione
-        $options[__('Senza regione')] = 'no_region';
-
-        // Aggiungi tutte le regioni
-        foreach (Region::all() as $region) {
-            $options[$region->name] = $region->id;
-        }
-
-        return $options;
     }
 }

--- a/lang/vendor/nova/it.json
+++ b/lang/vendor/nova/it.json
@@ -480,5 +480,8 @@
     "tracks": "Tracce",
     "Present": "Presente",
     "Deleted from OSMFEATURES": "Eliminato da OSMFEATURES",
-    "Not present (deleted from OSMFEATURES)": "Non presente (eliminato da OSMFEATURES)"
+    "Not present (deleted from OSMFEATURES)": "Non presente (eliminato da OSMFEATURES)",
+    "No area": "Senza area",
+    "No province": "Senza provincia",
+    "No region": "Senza regione"
 }


### PR DESCRIPTION
- Introduced `BaseOSMFeaturesFilter` as an abstract class to centralize common functionalities for OSM feature filters.
- Refactored `AreaFilter`, `ProvinceFilter`, and `RegionFilter` to extend `BaseOSMFeaturesFilter`, reducing duplicate code and improving consistency.
- Added new methods in `BaseOSMFeaturesFilter` to handle empty option labels and values, as well as entity-specific options and query applications.
- Updated language translations to include new labels for "No area", "No province", and "No region".
