### PR TITLE
feat(filters): ✨ add "without area/province" option in AreaFilter and ProvinceFilter OC:7206

### DIFF
--- a/app/Nova/Filters/AreaFilter.php
+++ b/app/Nova/Filters/AreaFilter.php
@@ -4,6 +4,8 @@ namespace App\Nova\Filters;
 
 use App\Enums\UserRole;
 use App\Models\Area;
+use App\Models\User;
+use App\Models\HikingRoute;
 use Illuminate\Http\Request;
 use Laravel\Nova\Filters\Filter;
 
@@ -32,13 +34,24 @@ class AreaFilter extends Filter
      */
     public function apply(Request $request, $query, $value)
     {
-        if ($query->getModel() instanceof \App\Models\HikingRoute) {
+        $model = $query->getModel();
+
+        // Gestione del caso "senza area"
+        if ($value === 'no_area') {
+            if ($model instanceof HikingRoute || $model instanceof User) {
+                return $query->whereDoesntHave('areas');
+            }
+
+            return $query->whereNull('area_id');
+        }
+
+        if ($model instanceof HikingRoute) {
             return $query->whereHas('areas', function ($query) use ($value) {
                 $query->where('area_id', $value);
             });
         }
 
-        if ($query->getModel() instanceof \App\Models\User) {
+        if ($model instanceof User) {
             return $query->whereHas('areas', function ($query) use ($value) {
                 $query->where('area_id', $value);
             });
@@ -55,6 +68,10 @@ class AreaFilter extends Filter
     public function options(Request $request)
     {
         $options = [];
+        
+        // Aggiungi l'opzione "Senza area" come prima opzione
+        $options[__('Senza area')] = 'no_area';
+
         if (auth()->user()->hasRole(UserRole::RegionalReferent)) {
             $areas = Area::whereIn('province_id', auth()->user()->region->provinces->pluck('id')->toArray())->orderBy('name')->get();
             foreach ($areas as $item) {

--- a/app/Nova/Filters/ProvinceFilter.php
+++ b/app/Nova/Filters/ProvinceFilter.php
@@ -4,6 +4,8 @@ namespace App\Nova\Filters;
 
 use App\Enums\UserRole;
 use App\Models\Province;
+use App\Models\User;
+use App\Models\HikingRoute;
 use Illuminate\Http\Request;
 use Laravel\Nova\Filters\Filter;
 
@@ -32,13 +34,24 @@ class ProvinceFilter extends Filter
      */
     public function apply(Request $request, $query, $value)
     {
-        if ($query->getModel() instanceof \App\Models\HikingRoute) {
+        $model = $query->getModel();
+
+        // Gestione del caso "senza provincia"
+        if ($value === 'no_province') {
+            if ($model instanceof HikingRoute || $model instanceof User) {
+                return $query->whereDoesntHave('provinces');
+            }
+
+            return $query->whereNull('province_id');
+        }
+
+        if ($model instanceof HikingRoute) {
             return $query->whereHas('provinces', function ($query) use ($value) {
                 $query->where('province_id', $value);
             });
         }
 
-        if ($query->getModel() instanceof \App\Models\User) {
+        if ($model instanceof User) {
             return $query->whereHas('provinces', function ($query) use ($value) {
                 $query->where('name', Province::find($value)->name);
             });
@@ -55,6 +68,10 @@ class ProvinceFilter extends Filter
     public function options(Request $request)
     {
         $options = [];
+        
+        // Aggiungi l'opzione "Senza provincia" come prima opzione
+        $options[__('Senza provincia')] = 'no_province';
+
         if (auth()->user()->hasRole(UserRole::RegionalReferent)) {
             $provinces = Province::where('region_id', auth()->user()->region->id)->orderBy('name')->get();
             foreach ($provinces as $item) {

--- a/tests/Unit/Nova/Filters/AreaFilterTest.php
+++ b/tests/Unit/Nova/Filters/AreaFilterTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Unit\Nova\Filters;
+
+use App\Models\Area;
+use App\Models\HikingRoute;
+use App\Models\User;
+use App\Nova\Filters\AreaFilter;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class AreaFilterTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function createRequest(): Request
+    {
+        return new Request;
+    }
+
+    private function createHikingRoute(): HikingRoute
+    {
+        return HikingRoute::factory()->createQuietly();
+    }
+
+    private function createArea(array $attributes = []): Area
+    {
+        return Area::factory()->createQuietly($attributes);
+    }
+
+    private function createUser(array $attributes = []): User
+    {
+        return User::find(User::factory()->createQuietly($attributes)->id);
+    }
+
+    public function test_apply_no_area_filters_hiking_routes_without_areas(): void
+    {
+        $filter = new AreaFilter;
+        $request = $this->createRequest();
+
+        $hikingRouteWithArea = $this->createHikingRoute();
+        $hikingRouteWithoutArea = $this->createHikingRoute();
+
+        $area = $this->createArea();
+        $hikingRouteWithArea->areas()->attach($area->id);
+
+        $query = HikingRoute::query();
+        $result = $filter->apply($request, $query, 'no_area')->get();
+
+        $this->assertTrue($result->contains($hikingRouteWithoutArea));
+        $this->assertFalse($result->contains($hikingRouteWithArea));
+    }
+
+    public function test_apply_specific_area_filters_hiking_routes_by_area(): void
+    {
+        $filter = new AreaFilter;
+        $request = $this->createRequest();
+
+        $areaOne = $this->createArea();
+        $areaTwo = $this->createArea();
+
+        $hikingRouteWithAreaOne = $this->createHikingRoute();
+        $hikingRouteWithAreaTwo = $this->createHikingRoute();
+        $hikingRouteWithoutArea = $this->createHikingRoute();
+
+        $hikingRouteWithAreaOne->areas()->attach($areaOne->id);
+        $hikingRouteWithAreaTwo->areas()->attach($areaTwo->id);
+
+        $query = HikingRoute::query();
+        $result = $filter->apply($request, $query, $areaOne->id)->get();
+
+        $this->assertTrue($result->contains($hikingRouteWithAreaOne));
+        $this->assertFalse($result->contains($hikingRouteWithAreaTwo));
+        $this->assertFalse($result->contains($hikingRouteWithoutArea));
+    }
+
+    public function test_apply_no_area_filters_users_without_areas(): void
+    {
+        $filter = new AreaFilter;
+        $request = $this->createRequest();
+
+        $userWithArea = $this->createUser();
+        $userWithoutArea = $this->createUser();
+
+        $area = $this->createArea();
+        $userWithArea->areas()->attach($area->id);
+
+        $query = User::query();
+        $result = $filter->apply($request, $query, 'no_area')->get();
+
+        $this->assertTrue($result->contains($userWithoutArea));
+        $this->assertFalse($result->contains($userWithArea));
+    }
+
+    public function test_apply_specific_area_filters_users_by_area(): void
+    {
+        $filter = new AreaFilter;
+        $request = $this->createRequest();
+
+        $areaOne = $this->createArea();
+        $areaTwo = $this->createArea();
+
+        $userWithAreaOne = $this->createUser();
+        $userWithAreaTwo = $this->createUser();
+        $userWithoutArea = $this->createUser();
+
+        $userWithAreaOne->areas()->attach($areaOne->id);
+        $userWithAreaTwo->areas()->attach($areaTwo->id);
+
+        $query = User::query();
+        $result = $filter->apply($request, $query, $areaOne->id)->get();
+
+        $this->assertTrue($result->contains($userWithAreaOne));
+        $this->assertFalse($result->contains($userWithAreaTwo));
+        $this->assertFalse($result->contains($userWithoutArea));
+    }
+
+    public function test_options_includes_no_area_and_all_areas_for_non_regional_user(): void
+    {
+        $filter = new AreaFilter;
+        $request = $this->createRequest();
+
+        /** @var User $user */
+        $user = $this->createUser();
+        $this->actingAs($user);
+
+        $areaOne = $this->createArea(['name' => 'AAA Area']);
+        $areaTwo = $this->createArea(['name' => 'BBB Area']);
+
+        $options = $filter->options($request);
+
+        $this->assertArrayHasKey(__('Senza area'), $options);
+        $this->assertSame('no_area', $options[__('Senza area')]);
+
+        $this->assertArrayHasKey($areaOne->name, $options);
+        $this->assertArrayHasKey($areaTwo->name, $options);
+
+        $this->assertEquals(__('Senza area'), array_key_first($options));
+    }
+}

--- a/tests/Unit/Nova/Filters/ProvinceFilterTest.php
+++ b/tests/Unit/Nova/Filters/ProvinceFilterTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Unit\Nova\Filters;
+
+use App\Models\HikingRoute;
+use App\Models\Province;
+use App\Models\User;
+use App\Nova\Filters\ProvinceFilter;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class ProvinceFilterTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function createRequest(): Request
+    {
+        return new Request();
+    }
+
+    private function createHikingRoute(): HikingRoute
+    {
+        return HikingRoute::factory()->createQuietly();
+    }
+
+    private function createProvince(array $attributes = []): Province
+    {
+        return Province::factory()->createQuietly($attributes);
+    }
+
+    private function createUser(array $attributes = []): User
+    {
+        return User::find(User::factory()->createQuietly($attributes)->id);
+    }
+
+    public function test_apply_no_province_filters_hiking_routes_without_provinces(): void
+    {
+        $filter = new ProvinceFilter();
+        $request = $this->createRequest();
+
+        $province = $this->createProvince();
+        $hikingRouteWithProvince = $this->createHikingRoute();
+        $hikingRouteWithoutProvince = $this->createHikingRoute();
+
+        $hikingRouteWithProvince->provinces()->attach($province->id);
+
+        $query = HikingRoute::query();
+        $result = $filter->apply($request, $query, 'no_province')->get();
+
+        $this->assertTrue($result->contains($hikingRouteWithoutProvince));
+        $this->assertFalse($result->contains($hikingRouteWithProvince));
+    }
+
+    public function test_apply_specific_province_filters_hiking_routes_by_province(): void
+    {
+        $filter = new ProvinceFilter();
+        $request = $this->createRequest();
+
+        $provinceOne = $this->createProvince();
+        $provinceTwo = $this->createProvince();
+
+        $hikingRouteOne = $this->createHikingRoute();
+        $hikingRouteTwo = $this->createHikingRoute();
+        $hikingRouteWithoutProvince = $this->createHikingRoute();
+
+        $hikingRouteOne->provinces()->attach($provinceOne->id);
+        $hikingRouteTwo->provinces()->attach($provinceTwo->id);
+
+        $query = HikingRoute::query();
+        $result = $filter->apply($request, $query, $provinceOne->id)->get();
+
+        $this->assertTrue($result->contains($hikingRouteOne));
+        $this->assertFalse($result->contains($hikingRouteTwo));
+        $this->assertFalse($result->contains($hikingRouteWithoutProvince));
+    }
+
+    public function test_apply_no_province_filters_users_without_provinces(): void
+    {
+        $filter = new ProvinceFilter();
+        $request = $this->createRequest();
+
+        $province = $this->createProvince();
+        $userWithProvince = $this->createUser();
+        $userWithoutProvince = $this->createUser();
+
+        $userWithProvince->provinces()->attach($province->id);
+
+        $query = User::query();
+        $result = $filter->apply($request, $query, 'no_province')->get();
+
+        $this->assertTrue($result->contains($userWithoutProvince));
+        $this->assertFalse($result->contains($userWithProvince));
+    }
+
+    public function test_apply_specific_province_filters_users_by_province(): void
+    {
+        $filter = new ProvinceFilter();
+        $request = $this->createRequest();
+
+        $provinceOne = $this->createProvince(['name' => 'Province One']);
+        $provinceTwo = $this->createProvince(['name' => 'Province Two']);
+
+        $userOne = $this->createUser();
+        $userTwo = $this->createUser();
+        $userWithoutProvince = $this->createUser();
+
+        $userOne->provinces()->attach($provinceOne->id);
+        $userTwo->provinces()->attach($provinceTwo->id);
+
+        $query = User::query();
+        $result = $filter->apply($request, $query, $provinceOne->id)->get();
+
+        $this->assertTrue($result->contains($userOne));
+        $this->assertFalse($result->contains($userTwo));
+        $this->assertFalse($result->contains($userWithoutProvince));
+    }
+
+    public function test_options_includes_no_province_and_all_provinces_for_non_regional_user(): void
+    {
+        $filter = new ProvinceFilter();
+        $request = $this->createRequest();
+
+        /** @var User $user */
+        $user = $this->createUser();
+        $this->actingAs($user);
+
+        $provinceOne = $this->createProvince(['name' => 'AAA Province']);
+        $provinceTwo = $this->createProvince(['name' => 'BBB Province']);
+
+        $options = $filter->options($request);
+
+        $this->assertArrayHasKey(__('Senza provincia'), $options);
+        $this->assertSame('no_province', $options[__('Senza provincia')]);
+        $this->assertArrayHasKey($provinceOne->name, $options);
+        $this->assertArrayHasKey($provinceTwo->name, $options);
+        $this->assertEquals(__('Senza provincia'), array_key_first($options));
+    }
+}

--- a/tests/Unit/Nova/Filters/RegionFilterTest.php
+++ b/tests/Unit/Nova/Filters/RegionFilterTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Tests\Unit\Nova\Filters;
+
+use App\Models\Club;
+use App\Models\HikingRoute;
+use App\Models\Province;
+use App\Models\Region;
+use App\Models\Sector;
+use App\Models\User;
+use App\Nova\Filters\RegionFilter;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Tests\TestCase;
+
+class RegionFilterTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function createNovaRequest(): NovaRequest
+    {
+        return NovaRequest::create('/nova-api/users', 'GET');
+    }
+
+    private function createHikingRoute(): HikingRoute
+    {
+        return HikingRoute::factory()->createQuietly();
+    }
+
+    private function createRegion(): Region
+    {
+        return Region::factory()->createQuietly();
+    }
+
+    private function createProvince(array $attributes = []): Province
+    {
+        $province = Province::factory()->createQuietly();
+        if ($attributes !== []) {
+            $province->forceFill($attributes)->save();
+        }
+        return $province;
+    }
+
+    private function createUser(array $attributes = []): User
+    {
+        return User::find(User::factory()->createQuietly($attributes)->id);
+    }
+
+    public function test_apply_no_region_filters_provinces_without_region(): void
+    {
+        $filter = new RegionFilter();
+        $request = $this->createNovaRequest();
+
+        $region = $this->createRegion();
+        $provinceWithRegion = $this->createProvince(['region_id' => $region->id]);
+        $provinceWithoutRegion = $this->createProvince(['region_id' => null]);
+
+        $query = Province::query();
+        $result = $filter->apply($request, $query, 'no_region')->get();
+
+        $this->assertTrue($result->contains($provinceWithoutRegion));
+        $this->assertFalse($result->contains($provinceWithRegion));
+    }
+
+    public function test_apply_specific_region_filters_provinces_by_region(): void
+    {
+        $filter = new RegionFilter();
+        $request = $this->createNovaRequest();
+
+        $regionOne = $this->createRegion();
+        $regionTwo = $this->createRegion();
+
+        $provinceOne = $this->createProvince(['region_id' => $regionOne->id]);
+        $provinceTwo = $this->createProvince(['region_id' => $regionTwo->id]);
+
+        $query = Province::query();
+        $result = $filter->apply($request, $query, $regionOne->id)->get();
+
+        $this->assertTrue($result->contains($provinceOne));
+        $this->assertFalse($result->contains($provinceTwo));
+    }
+
+    public function test_apply_no_region_filters_users_without_region(): void
+    {
+        $filter = new RegionFilter();
+        $request = $this->createNovaRequest();
+
+        $region = $this->createRegion();
+        $userWithRegion = $this->createUser(['region_id' => $region->id]);
+        $userWithoutRegion = $this->createUser(['region_id' => null]);
+
+        $query = User::query();
+        $result = $filter->apply($request, $query, 'no_region')->get();
+
+        $this->assertTrue($result->contains($userWithoutRegion));
+        $this->assertFalse($result->contains($userWithRegion));
+    }
+
+    public function test_apply_specific_region_filters_users_by_region(): void
+    {
+        $filter = new RegionFilter();
+        $request = $this->createNovaRequest();
+
+        $regionOne = $this->createRegion();
+        $regionTwo = $this->createRegion();
+
+        $userOne = $this->createUser(['region_id' => $regionOne->id]);
+        $userTwo = $this->createUser(['region_id' => $regionTwo->id]);
+
+        $query = User::query();
+        $result = $filter->apply($request, $query, $regionOne->id)->get();
+
+        $this->assertTrue($result->contains($userOne));
+        $this->assertFalse($result->contains($userTwo));
+    }
+
+    public function test_apply_no_region_filters_hiking_routes_without_regions(): void
+    {
+        $filter = new RegionFilter();
+        $request = $this->createNovaRequest();
+
+        $region = $this->createRegion();
+        $hikingRouteWithRegion = $this->createHikingRoute();
+        $hikingRouteWithoutRegion = $this->createHikingRoute();
+
+        $hikingRouteWithRegion->regions()->attach($region->id);
+
+        $query = HikingRoute::query();
+        $result = $filter->apply($request, $query, 'no_region')->get();
+
+        $this->assertTrue($result->contains($hikingRouteWithoutRegion));
+        $this->assertFalse($result->contains($hikingRouteWithRegion));
+    }
+
+    public function test_apply_specific_region_filters_hiking_routes_by_region(): void
+    {
+        $filter = new RegionFilter();
+        $request = $this->createNovaRequest();
+
+        $regionOne = $this->createRegion();
+        $regionTwo = $this->createRegion();
+
+        $hikingRouteOne = $this->createHikingRoute();
+        $hikingRouteTwo = $this->createHikingRoute();
+        $hikingRouteWithoutRegion = $this->createHikingRoute();
+
+        $hikingRouteOne->regions()->attach($regionOne->id);
+        $hikingRouteTwo->regions()->attach($regionTwo->id);
+
+        $query = HikingRoute::query();
+        $result = $filter->apply($request, $query, $regionOne->id)->get();
+
+        $this->assertTrue($result->contains($hikingRouteOne));
+        $this->assertFalse($result->contains($hikingRouteTwo));
+        $this->assertFalse($result->contains($hikingRouteWithoutRegion));
+    }
+
+    public function test_options_includes_no_region_and_all_regions(): void
+    {
+        $filter = new RegionFilter();
+        $request = $this->createNovaRequest();
+
+        /** @var User $user */
+        $user = $this->createUser();
+        $this->actingAs($user);
+
+        $regionOne = $this->createRegion(['name' => 'AAA Region']);
+        $regionTwo = $this->createRegion(['name' => 'BBB Region']);
+
+        $options = $filter->options($request);
+
+        $this->assertArrayHasKey(__('Senza regione'), $options);
+        $this->assertSame('no_region', $options[__('Senza regione')]);
+        $this->assertArrayHasKey($regionOne->name, $options);
+        $this->assertArrayHasKey($regionTwo->name, $options);
+        $this->assertEquals(__('Senza regione'), array_key_first($options));
+    }
+}

--- a/tests/Unit/Nova/Filters/SectorFilterTest.php
+++ b/tests/Unit/Nova/Filters/SectorFilterTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Unit\Nova\Filters;
+
+use App\Models\HikingRoute;
+use App\Models\Sector;
+use App\Models\User;
+use App\Nova\Filters\SectorFilter;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Tests\TestCase;
+
+class SectorFilterTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private const SECTOR_GEOMETRY = "ST_GeomFromText('MULTIPOLYGON(((0 0, 10 0, 10 10, 0 10, 0 0)))', 4326)";
+
+    protected function createNovaRequest(): NovaRequest
+    {
+        return NovaRequest::create('/nova-api/hiking-routes', 'GET');
+    }
+
+    private function createSector(array $attributes = []): Sector
+    {
+        return Sector::factory()->create(array_merge(
+            ['geometry' => DB::raw(self::SECTOR_GEOMETRY)],
+            $attributes
+        ));
+    }
+
+    private function createHikingRoute(): HikingRoute
+    {
+        return HikingRoute::factory()->createQuietly();
+    }
+
+    private function createUser(array $attributes = []): User
+    {
+        return User::find(User::factory()->createQuietly($attributes)->id);
+    }
+
+    public function test_apply_no_sector_filters_hiking_routes_without_sectors(): void
+    {
+        $filter = new SectorFilter();
+        $request = $this->createNovaRequest();
+
+        $sector = $this->createSector();
+        $hikingRouteWithSector = $this->createHikingRoute();
+        $hikingRouteWithoutSector = $this->createHikingRoute();
+
+        $hikingRouteWithSector->sectors()->attach($sector->id, ['percentage' => 100]);
+
+        $query = HikingRoute::query();
+        $result = $filter->apply($request, $query, 'no_sector')->get();
+
+        $this->assertTrue($result->contains($hikingRouteWithoutSector));
+        $this->assertFalse($result->contains($hikingRouteWithSector));
+    }
+
+    public function test_apply_specific_sector_filters_hiking_routes_by_sector(): void
+    {
+        $filter = new SectorFilter();
+        $request = $this->createNovaRequest();
+
+        $sectorOne = $this->createSector();
+        $sectorTwo = $this->createSector();
+
+        $hikingRouteOne = $this->createHikingRoute();
+        $hikingRouteTwo = $this->createHikingRoute();
+        $hikingRouteWithoutSector = $this->createHikingRoute();
+
+        $hikingRouteOne->sectors()->attach($sectorOne->id, ['percentage' => 100]);
+        $hikingRouteTwo->sectors()->attach($sectorTwo->id, ['percentage' => 100]);
+
+        $query = HikingRoute::query();
+        $result = $filter->apply($request, $query, $sectorOne->id)->get();
+
+        $this->assertTrue($result->contains($hikingRouteOne));
+        $this->assertFalse($result->contains($hikingRouteTwo));
+        $this->assertFalse($result->contains($hikingRouteWithoutSector));
+    }
+
+    public function test_options_includes_no_sector_and_all_sectors_for_non_regional_user(): void
+    {
+        $filter = new SectorFilter();
+        $request = $this->createNovaRequest();
+
+        /** @var User $user */
+        $user = $this->createUser();
+        $this->actingAs($user);
+
+        $sectorOne = $this->createSector(['full_code' => 'AA']);
+        $sectorTwo = $this->createSector(['full_code' => 'BB']);
+
+        $options = $filter->options($request);
+
+        $this->assertArrayHasKey(__('Senza settore'), $options);
+        $this->assertSame('no_sector', $options[__('Senza settore')]);
+        $this->assertArrayHasKey($sectorOne->full_code, $options);
+        $this->assertArrayHasKey($sectorTwo->full_code, $options);
+        $this->assertEquals(__('Senza settore'), array_key_first($options));
+    }
+}


### PR DESCRIPTION
- Introduced a "without area" option in AreaFilter and "without province" option in ProvinceFilter.
- Updated the apply method in both filters to handle queries that do not have associated areas or provinces.
- Added User and HikingRoute models to the filters to support the new option.
- Updated options method to include the new "Senza area" and "Senza provincia" options as the first selectable choice.
