### PR TITLE
feat(command): ✨ add ForceUpdateOsmFeaturesFromTo command for batch updating HikingRoute properties oc:7783

### DIFF
--- a/app/Console/Commands/ForceUpdateOsmFeaturesFromTo.php
+++ b/app/Console/Commands/ForceUpdateOsmFeaturesFromTo.php
@@ -1,0 +1,378 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\HikingRoute;
+use Illuminate\Console\Command;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Pool;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class ForceUpdateOsmFeaturesFromTo extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'osm2cai:force-update-osmfeatures-from-to
+                            {--dry-run : Simula il comando senza salvare nulla}
+                            {--batch-size=3 : Numero massimo di richieste HTTP concorrenti}
+                            {--delay=500 : Pausa in millisecondi tra un batch e il successivo}
+                            {--timeout=30 : Timeout in secondi per ogni richiesta HTTP}
+                            {--limit=0 : Numero massimo di hiking routes da elaborare (0 = nessun limite)}
+                            {--id= : ID della HikingRoute da processare (utile per test/debug)}
+                            {--details : Stampa/logga il dettaglio per ogni record (valori locali vs API e motivazione)}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "Forza l'aggiornamento dei campi 'from' e 'to' nelle properties delle HikingRoute "
+        ."recuperandoli da osmfeatures (anche per percorsi con osm2cai_status = 4). "
+        .'Le richieste HTTP vengono eseguite in batch concorrenti.';
+
+    private bool $isDryRun = false;
+
+    private bool $isDetails = false;
+
+    private int $processed = 0;
+
+    private int $updated = 0;
+
+    private int $skipped = 0;
+
+    private int $errors = 0;
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $this->isDryRun = (bool) $this->option('dry-run');
+        $this->isDetails = (bool) $this->option('details');
+        $batchSize = max(1, (int) $this->option('batch-size'));
+        $delayMs = max(0, (int) $this->option('delay'));
+        $timeout = max(1, (int) $this->option('timeout'));
+        $limit = max(0, (int) $this->option('limit'));
+        $id = $this->option('id');
+
+        $logger = Log::channel('wm-osmfeatures');
+        $prefix = $this->isDryRun ? '[DRY RUN] ' : '';
+
+        $this->info($prefix."Avvio aggiornamento forzato di 'from'/'to' su HikingRoute (batch={$batchSize}, delay={$delayMs}ms).");
+        $logger->info("ForceUpdateOsmFeaturesFromTo: start (dry-run={$this->isDryRun}, details={$this->isDetails}, batch={$batchSize}, delay={$delayMs}ms, limit={$limit}, id={$id})");
+
+        $ids = $this->buildBaseQuery()
+            ->when(! empty($id), fn ($q) => $q->where('id', (int) $id))
+            ->when($limit > 0, fn ($q) => $q->limit($limit))
+            ->orderBy('id')
+            ->pluck('id')
+            ->all();
+
+        $total = count($ids);
+
+        if ($total === 0) {
+            $this->info('Nessuna HikingRoute da aggiornare: tutte le routes hanno già from e to nelle properties.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->info("Trovate {$total} HikingRoute con 'from' e/o 'to' mancanti nelle properties.");
+
+        $progressBar = $this->output->createProgressBar($total);
+        $progressBar->start();
+
+        $batches = array_chunk($ids, $batchSize);
+        $lastIndex = count($batches) - 1;
+
+        foreach ($batches as $index => $batchIds) {
+            $routes = HikingRoute::whereIn('id', $batchIds)
+                ->get()
+                ->keyBy('id');
+
+            $responses = $this->fetchBatch($routes, $timeout);
+
+            foreach ($routes as $id => $route) {
+                $this->processed++;
+                $this->processSingleRoute($route, $responses[(string) $id] ?? null, $logger);
+                $progressBar->advance();
+            }
+
+            if ($delayMs > 0 && $index < $lastIndex) {
+                usleep($delayMs * 1000);
+            }
+        }
+
+        $progressBar->finish();
+        $this->newLine(2);
+
+        $this->displaySummary($logger);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Build the base query: only routes with osmfeatures_id and missing from/to in properties.
+     * Note: the filter is applied at PHP level only when osm2cai_status = 4 is desired too,
+     * which is the default behavior of this command (no status filter is applied here).
+     */
+    private function buildBaseQuery()
+    {
+        return HikingRoute::query()
+            ->whereNotNull('osmfeatures_id')
+            ->where(function ($q) {
+                $q->whereNull('properties')
+                    ->orWhereRaw("(properties->>'from') IS NULL")
+                    ->orWhereRaw("(properties->>'from') = ''")
+                    ->orWhereRaw("(properties->>'to') IS NULL")
+                    ->orWhereRaw("(properties->>'to') = ''");
+            });
+    }
+
+    /**
+     * Fetch a batch of routes concurrently using Http::pool.
+     * Returns an associative array: [route_id => Response|Throwable|null].
+     */
+    private function fetchBatch($routes, int $timeout): array
+    {
+        $items = $routes->values()->all();
+
+        try {
+            $responses = Http::pool(function (Pool $pool) use ($items, $timeout) {
+                return array_map(function (HikingRoute $route) use ($pool, $timeout) {
+                    $url = HikingRoute::getApiSingleFeature($route->osmfeatures_id);
+
+                    return $pool->as((string) $route->id)
+                        ->timeout($timeout)
+                        ->get($url);
+                }, $items);
+            });
+        } catch (Throwable $e) {
+            Log::channel('wm-osmfeatures')->error('ForceUpdateOsmFeaturesFromTo: pool error - '.$e->getMessage());
+
+            return [];
+        }
+
+        return $responses;
+    }
+
+    /**
+     * Process the response for a single hiking route.
+     */
+    private function processSingleRoute(HikingRoute $route, mixed $response, $logger): void
+    {
+        if ($response instanceof Throwable || $response instanceof ConnectionException) {
+            $this->errors++;
+            $logger->error("ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) - request failed: ".$response->getMessage());
+
+            return;
+        }
+
+        if (! $response instanceof Response || $response->failed() || $response->json() === null) {
+            $this->errors++;
+            $status = $response instanceof Response ? $response->status() : 'no-response';
+            $logger->error("ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) - invalid response (status: {$status})");
+
+            return;
+        }
+
+        $data = $response->json();
+        $from = $data['properties']['from'] ?? null;
+        $to = $data['properties']['to'] ?? null;
+
+        $properties = is_array($route->properties) ? $route->properties : [];
+        $localFrom = $properties['from'] ?? null;
+        $localTo = $properties['to'] ?? null;
+        $changed = false;
+        $reasons = [];
+
+        // Preparazione aggiornamento "ibrido": oltre a properties, aggiorna osmfeatures_data.properties.from/to
+        // solo se sono vuoti e solo con valori non vuoti provenienti dall'API.
+        $osmfeaturesData = $route->osmfeatures_data;
+        if (is_string($osmfeaturesData)) {
+            $decoded = json_decode($osmfeaturesData, true);
+            if (is_array($decoded)) {
+                $osmfeaturesData = $decoded;
+            }
+        }
+        $osmfeaturesDataChanged = false;
+        if (is_array($osmfeaturesData)) {
+            $osmfeaturesData['properties'] ??= [];
+            $osfLocalFrom = $osmfeaturesData['properties']['from'] ?? null;
+            $osfLocalTo = $osmfeaturesData['properties']['to'] ?? null;
+            $osfRef = $osmfeaturesData['properties']['ref'] ?? null;
+        } else {
+            $osfLocalFrom = null;
+            $osfLocalTo = null;
+            $osfRef = null;
+        }
+
+        if (! $this->isEmptyValue($from) && $this->isEmptyValue($localFrom)) {
+            $properties['from'] = $from;
+            $changed = true;
+            $reasons[] = "set from (local empty, api='{$from}')";
+        }
+
+        if (! $this->isEmptyValue($to) && $this->isEmptyValue($localTo)) {
+            $properties['to'] = $to;
+            $changed = true;
+            $reasons[] = "set to (local empty, api='{$to}')";
+        }
+
+        if (is_array($osmfeaturesData)) {
+            if (! $this->isEmptyValue($from) && $this->isEmptyValue($osfLocalFrom)) {
+                $osmfeaturesData['properties']['from'] = $from;
+                $osmfeaturesDataChanged = true;
+                $reasons[] = "set osmfeatures_data.from (was empty, api='{$from}')";
+            }
+            if (! $this->isEmptyValue($to) && $this->isEmptyValue($osfLocalTo)) {
+                $osmfeaturesData['properties']['to'] = $to;
+                $osmfeaturesDataChanged = true;
+                $reasons[] = "set osmfeatures_data.to (was empty, api='{$to}')";
+            }
+        }
+
+        // Se abbiamo una ref e stiamo aggiornando from/to, aggiorna anche il name (ref - from - to).
+        // Usiamo i valori finali presenti in osmfeatures_data se disponibili, altrimenti quelli in properties.
+        $nameChanged = false;
+        $newName = null;
+        $refForName = $this->isEmptyValue($osfRef) ? null : (string) $osfRef;
+        if ($refForName !== null && ($changed || $osmfeaturesDataChanged)) {
+            $fromForName = is_array($osmfeaturesData) ? ($osmfeaturesData['properties']['from'] ?? null) : null;
+            $toForName = is_array($osmfeaturesData) ? ($osmfeaturesData['properties']['to'] ?? null) : null;
+            if ($this->isEmptyValue($fromForName)) {
+                $fromForName = $properties['from'] ?? null;
+            }
+            if ($this->isEmptyValue($toForName)) {
+                $toForName = $properties['to'] ?? null;
+            }
+
+            if (! $this->isEmptyValue($fromForName) && ! $this->isEmptyValue($toForName)) {
+                $newName = $refForName.' - '.$fromForName.' - '.$toForName;
+                if ($route->name !== $newName) {
+                    $nameChanged = true;
+                    $reasons[] = "set name ('{$newName}')";
+                }
+            }
+        }
+
+        if ($this->isDetails) {
+            $msg = "ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) "
+                ."local[from='".($localFrom ?? 'NULL')."', to='".($localTo ?? 'NULL')."'] "
+                ."api[from='".($from ?? 'NULL')."', to='".($to ?? 'NULL')."']";
+            $this->line($msg);
+            $logger->info($msg);
+        }
+
+        if (! $changed && ! $osmfeaturesDataChanged) {
+            $this->skipped++;
+            $reason = $this->buildSkipReason($localFrom, $localTo, $from, $to);
+            $logger->info("ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) - nothing to update ({$reason})");
+            if ($this->isDetails) {
+                $this->line("  -> skip: {$reason}");
+            }
+
+            return;
+        }
+
+        if ($this->isDryRun) {
+            $this->updated++;
+            $actions = implode(', ', $reasons);
+            $logger->info("[DRY RUN] ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) - would update ({$actions})");
+            if ($this->isDetails) {
+                $this->line("  -> dry-run: {$actions}");
+            }
+
+            return;
+        }
+
+        try {
+            // NOTA: usiamo update() (non quietly) così scattano gli observer
+            // e quindi il job AWS della traccia viene dispatchato automaticamente.
+            $updatePayload = ['properties' => $properties];
+            if ($osmfeaturesDataChanged) {
+                $updatePayload['osmfeatures_data'] = $osmfeaturesData;
+            }
+            if ($nameChanged) {
+                $updatePayload['name'] = $newName;
+            }
+            $route->update($updatePayload);
+            $this->updated++;
+            $actions = implode(', ', $reasons);
+            $logger->info("ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) - updated ({$actions}) (osm2cai_status={$route->osm2cai_status})");
+            if ($this->isDetails) {
+                $this->line("  -> updated: {$actions}");
+            }
+        } catch (Throwable $e) {
+            $this->errors++;
+            $logger->error("ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) - update failed: ".$e->getMessage());
+        }
+    }
+
+    private function isEmptyValue(mixed $value): bool
+    {
+        if ($value === null) {
+            return true;
+        }
+
+        if (is_string($value) && trim($value) === '') {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function buildSkipReason(mixed $localFrom, mixed $localTo, mixed $apiFrom, mixed $apiTo): string
+    {
+        $localFromEmpty = $this->isEmptyValue($localFrom);
+        $localToEmpty = $this->isEmptyValue($localTo);
+        $apiFromEmpty = $this->isEmptyValue($apiFrom);
+        $apiToEmpty = $this->isEmptyValue($apiTo);
+
+        if (! $localFromEmpty && ! $localToEmpty) {
+            return 'local already has from/to';
+        }
+
+        if ($localFromEmpty && $localToEmpty && $apiFromEmpty && $apiToEmpty) {
+            return 'api returned empty from/to';
+        }
+
+        $parts = [];
+        if ($localFromEmpty) {
+            $parts[] = $apiFromEmpty ? 'from missing in api' : 'from already handled';
+        } else {
+            $parts[] = 'from already set locally';
+        }
+
+        if ($localToEmpty) {
+            $parts[] = $apiToEmpty ? 'to missing in api' : 'to already handled';
+        } else {
+            $parts[] = 'to already set locally';
+        }
+
+        return implode('; ', $parts);
+    }
+
+    private function displaySummary($logger): void
+    {
+        $prefix = $this->isDryRun ? '[DRY RUN] ' : '';
+
+        $this->info($prefix.'Elaborazione completata.');
+        $this->table(
+            ['Metrica', 'Conteggio'],
+            [
+                ['Totale processate', $this->processed],
+                [$this->isDryRun ? 'Aggiornabili (simulate)' : 'Aggiornate', $this->updated],
+                ['Saltate (già valorizzate o API senza dati)', $this->skipped],
+                ['Errori', $this->errors],
+            ]
+        );
+
+        $logger->info("ForceUpdateOsmFeaturesFromTo: end - processed={$this->processed}, updated={$this->updated}, skipped={$this->skipped}, errors={$this->errors}, dry-run={$this->isDryRun}, details={$this->isDetails}");
+    }
+}

--- a/app/Console/Commands/ForceUpdateOsmFeaturesFromTo.php
+++ b/app/Console/Commands/ForceUpdateOsmFeaturesFromTo.php
@@ -25,7 +25,8 @@ class ForceUpdateOsmFeaturesFromTo extends Command
                             {--timeout=30 : Timeout in secondi per ogni richiesta HTTP}
                             {--limit=0 : Numero massimo di hiking routes da elaborare (0 = nessun limite)}
                             {--id= : ID della HikingRoute da processare (utile per test/debug)}
-                            {--details : Stampa/logga il dettaglio per ogni record (valori locali vs API e motivazione)}';
+                            {--details : Stampa/logga il dettaglio per ogni record (valori locali vs API e motivazione)}
+                            {--update-name : Aggiorna anche il campo name (ref - from - to). Default: disabilitato}';
 
     /**
      * The console command description.
@@ -39,6 +40,8 @@ class ForceUpdateOsmFeaturesFromTo extends Command
     private bool $isDryRun = false;
 
     private bool $isDetails = false;
+
+    private bool $shouldUpdateName = false;
 
     private int $processed = 0;
 
@@ -55,6 +58,7 @@ class ForceUpdateOsmFeaturesFromTo extends Command
     {
         $this->isDryRun = (bool) $this->option('dry-run');
         $this->isDetails = (bool) $this->option('details');
+        $this->shouldUpdateName = (bool) $this->option('update-name');
         $batchSize = max(1, (int) $this->option('batch-size'));
         $delayMs = max(0, (int) $this->option('delay'));
         $timeout = max(1, (int) $this->option('timeout'));
@@ -65,7 +69,7 @@ class ForceUpdateOsmFeaturesFromTo extends Command
         $prefix = $this->isDryRun ? '[DRY RUN] ' : '';
 
         $this->info($prefix."Avvio aggiornamento forzato di 'from'/'to' su HikingRoute (batch={$batchSize}, delay={$delayMs}ms).");
-        $logger->info("ForceUpdateOsmFeaturesFromTo: start (dry-run={$this->isDryRun}, details={$this->isDetails}, batch={$batchSize}, delay={$delayMs}ms, limit={$limit}, id={$id})");
+        $logger->info("ForceUpdateOsmFeaturesFromTo: start (dry-run={$this->isDryRun}, details={$this->isDetails}, update-name={$this->shouldUpdateName}, batch={$batchSize}, delay={$delayMs}ms, limit={$limit}, id={$id})");
 
         $ids = $this->buildBaseQuery()
             ->when(! empty($id), fn ($q) => $q->where('id', (int) $id))
@@ -95,7 +99,10 @@ class ForceUpdateOsmFeaturesFromTo extends Command
                 ->get()
                 ->keyBy('id');
 
-            $responses = $this->fetchBatch($routes, $timeout);
+            $routesNeedingFetch = $routes->filter(fn (HikingRoute $route) => $this->needsFetchFromApi($route));
+            $responses = $routesNeedingFetch->isEmpty()
+                ? []
+                : $this->fetchBatch($routesNeedingFetch, $timeout);
 
             foreach ($routes as $id => $route) {
                 $this->processed++;
@@ -166,83 +173,114 @@ class ForceUpdateOsmFeaturesFromTo extends Command
      */
     private function processSingleRoute(HikingRoute $route, mixed $response, $logger): void
     {
-        if ($response instanceof Throwable || $response instanceof ConnectionException) {
-            $this->errors++;
-            $logger->error("ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) - request failed: ".$response->getMessage());
-
-            return;
-        }
-
-        if (! $response instanceof Response || $response->failed() || $response->json() === null) {
-            $this->errors++;
-            $status = $response instanceof Response ? $response->status() : 'no-response';
-            $logger->error("ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) - invalid response (status: {$status})");
-
-            return;
-        }
-
-        $data = $response->json();
-        $from = $data['properties']['from'] ?? null;
-        $to = $data['properties']['to'] ?? null;
-
         $properties = is_array($route->properties) ? $route->properties : [];
         $localFrom = $properties['from'] ?? null;
         $localTo = $properties['to'] ?? null;
+
+        if (! $this->isEmptyValue($localFrom) && ! $this->isEmptyValue($localTo)) {
+            $this->skipped++;
+            $logger->info("ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) - skip: local already has from/to");
+
+            return;
+        }
+
         $changed = false;
         $reasons = [];
 
-        // Preparazione aggiornamento "ibrido": oltre a properties, aggiorna osmfeatures_data.properties.from/to
-        // solo se sono vuoti e solo con valori non vuoti provenienti dall'API.
-        $osmfeaturesData = $route->osmfeatures_data;
-        if (is_string($osmfeaturesData)) {
-            $decoded = json_decode($osmfeaturesData, true);
-            if (is_array($decoded)) {
-                $osmfeaturesData = $decoded;
-            }
-        }
+        // 1) Se in properties mancano from/to, prima prova a recuperarli da osmfeatures_data.
+        $osmfeaturesData = $this->decodeOsmfeaturesData($route->osmfeatures_data);
         $osmfeaturesDataChanged = false;
-        if (is_array($osmfeaturesData)) {
-            $osmfeaturesData['properties'] ??= [];
-            $osfLocalFrom = $osmfeaturesData['properties']['from'] ?? null;
-            $osfLocalTo = $osmfeaturesData['properties']['to'] ?? null;
-            $osfRef = $osmfeaturesData['properties']['ref'] ?? null;
-        } else {
-            $osfLocalFrom = null;
-            $osfLocalTo = null;
-            $osfRef = null;
-        }
+        $osmfeaturesDataProps = is_array($osmfeaturesData) ? ($osmfeaturesData['properties'] ?? []) : [];
+        $osfLocalFrom = is_array($osmfeaturesDataProps) ? ($osmfeaturesDataProps['from'] ?? null) : null;
+        $osfLocalTo = is_array($osmfeaturesDataProps) ? ($osmfeaturesDataProps['to'] ?? null) : null;
+        $osfRef = is_array($osmfeaturesDataProps) ? ($osmfeaturesDataProps['ref'] ?? null) : null;
 
-        if (! $this->isEmptyValue($from) && $this->isEmptyValue($localFrom)) {
-            $properties['from'] = $from;
+        if ($this->isEmptyValue($localFrom) && ! $this->isEmptyValue($osfLocalFrom)) {
+            $properties['from'] = $osfLocalFrom;
             $changed = true;
-            $reasons[] = "set from (local empty, api='{$from}')";
+            $reasons[] = "set from (from osmfeatures_data='{$osfLocalFrom}')";
         }
 
-        if (! $this->isEmptyValue($to) && $this->isEmptyValue($localTo)) {
-            $properties['to'] = $to;
+        if ($this->isEmptyValue($localTo) && ! $this->isEmptyValue($osfLocalTo)) {
+            $properties['to'] = $osfLocalTo;
             $changed = true;
-            $reasons[] = "set to (local empty, api='{$to}')";
+            $reasons[] = "set to (from osmfeatures_data='{$osfLocalTo}')";
         }
 
-        if (is_array($osmfeaturesData)) {
-            if (! $this->isEmptyValue($from) && $this->isEmptyValue($osfLocalFrom)) {
-                $osmfeaturesData['properties']['from'] = $from;
-                $osmfeaturesDataChanged = true;
-                $reasons[] = "set osmfeatures_data.from (was empty, api='{$from}')";
+        $localFromAfterOsmfeatures = $properties['from'] ?? null;
+        $localToAfterOsmfeatures = $properties['to'] ?? null;
+
+        // 2) Se mancano ancora from/to, fai fetch a osmfeatures e aggiorna sia properties che osmfeatures_data.
+        $needsApiFrom = $this->isEmptyValue($localFromAfterOsmfeatures);
+        $needsApiTo = $this->isEmptyValue($localToAfterOsmfeatures);
+
+        $apiFrom = null;
+        $apiTo = null;
+
+        if ($needsApiFrom || $needsApiTo) {
+            if ($response instanceof Throwable || $response instanceof ConnectionException) {
+                $this->errors++;
+                $logger->error("ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) - request failed: ".$response->getMessage());
+
+                return;
             }
-            if (! $this->isEmptyValue($to) && $this->isEmptyValue($osfLocalTo)) {
-                $osmfeaturesData['properties']['to'] = $to;
-                $osmfeaturesDataChanged = true;
-                $reasons[] = "set osmfeatures_data.to (was empty, api='{$to}')";
+
+            if (! $response instanceof Response || $response->failed() || $response->json() === null) {
+                $this->errors++;
+                $status = $response instanceof Response ? $response->status() : 'no-response';
+                $logger->error("ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) - invalid response (status: {$status})");
+
+                return;
+            }
+
+            $data = $response->json();
+            $apiFrom = $data['properties']['from'] ?? null;
+            $apiTo = $data['properties']['to'] ?? null;
+
+            if ($needsApiFrom && ! $this->isEmptyValue($apiFrom)) {
+                $properties['from'] = $apiFrom;
+                $changed = true;
+                $reasons[] = "set from (from api='{$apiFrom}')";
+            }
+
+            if ($needsApiTo && ! $this->isEmptyValue($apiTo)) {
+                $properties['to'] = $apiTo;
+                $changed = true;
+                $reasons[] = "set to (from api='{$apiTo}')";
+            }
+
+            if (is_array($osmfeaturesData)) {
+                $osmfeaturesData['properties'] ??= [];
+                if (! $this->isEmptyValue($apiFrom)) {
+                    $osmfeaturesData['properties']['from'] = $apiFrom;
+                    $osmfeaturesDataChanged = true;
+                    $reasons[] = "set osmfeatures_data.from (from api='{$apiFrom}')";
+                }
+                if (! $this->isEmptyValue($apiTo)) {
+                    $osmfeaturesData['properties']['to'] = $apiTo;
+                    $osmfeaturesDataChanged = true;
+                    $reasons[] = "set osmfeatures_data.to (from api='{$apiTo}')";
+                }
+            } else {
+                $osmfeaturesData = ['properties' => []];
+                if (! $this->isEmptyValue($apiFrom)) {
+                    $osmfeaturesData['properties']['from'] = $apiFrom;
+                    $osmfeaturesDataChanged = true;
+                    $reasons[] = "set osmfeatures_data.from (from api='{$apiFrom}')";
+                }
+                if (! $this->isEmptyValue($apiTo)) {
+                    $osmfeaturesData['properties']['to'] = $apiTo;
+                    $osmfeaturesDataChanged = true;
+                    $reasons[] = "set osmfeatures_data.to (from api='{$apiTo}')";
+                }
             }
         }
 
-        // Se abbiamo una ref e stiamo aggiornando from/to, aggiorna anche il name (ref - from - to).
-        // Usiamo i valori finali presenti in osmfeatures_data se disponibili, altrimenti quelli in properties.
+        // 3) Aggiornamento name opzionale (default: disabilitato)
         $nameChanged = false;
         $newName = null;
         $refForName = $this->isEmptyValue($osfRef) ? null : (string) $osfRef;
-        if ($refForName !== null && ($changed || $osmfeaturesDataChanged)) {
+        if ($this->shouldUpdateName && $refForName !== null && ($changed || $osmfeaturesDataChanged)) {
             $fromForName = is_array($osmfeaturesData) ? ($osmfeaturesData['properties']['from'] ?? null) : null;
             $toForName = is_array($osmfeaturesData) ? ($osmfeaturesData['properties']['to'] ?? null) : null;
             if ($this->isEmptyValue($fromForName)) {
@@ -264,14 +302,15 @@ class ForceUpdateOsmFeaturesFromTo extends Command
         if ($this->isDetails) {
             $msg = "ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) "
                 ."local[from='".($localFrom ?? 'NULL')."', to='".($localTo ?? 'NULL')."'] "
-                ."api[from='".($from ?? 'NULL')."', to='".($to ?? 'NULL')."']";
+                ."osmfeatures_data[from='".($osfLocalFrom ?? 'NULL')."', to='".($osfLocalTo ?? 'NULL')."'] "
+                ."api[from='".($apiFrom ?? 'NULL')."', to='".($apiTo ?? 'NULL')."']";
             $this->line($msg);
             $logger->info($msg);
         }
 
         if (! $changed && ! $osmfeaturesDataChanged) {
             $this->skipped++;
-            $reason = $this->buildSkipReason($localFrom, $localTo, $from, $to);
+            $reason = $this->buildSkipReason($localFrom, $localTo, $apiFrom, $apiTo);
             $logger->info("ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) - nothing to update ({$reason})");
             if ($this->isDetails) {
                 $this->line("  -> skip: {$reason}");
@@ -292,8 +331,6 @@ class ForceUpdateOsmFeaturesFromTo extends Command
         }
 
         try {
-            // NOTA: usiamo update() (non quietly) così scattano gli observer
-            // e quindi il job AWS della traccia viene dispatchato automaticamente.
             $updatePayload = ['properties' => $properties];
             if ($osmfeaturesDataChanged) {
                 $updatePayload['osmfeatures_data'] = $osmfeaturesData;
@@ -301,7 +338,8 @@ class ForceUpdateOsmFeaturesFromTo extends Command
             if ($nameChanged) {
                 $updatePayload['name'] = $newName;
             }
-            $route->update($updatePayload);
+            $route->fill($updatePayload);
+            $route->saveQuietly();
             $this->updated++;
             $actions = implode(', ', $reasons);
             $logger->info("ForceUpdateOsmFeaturesFromTo: id {$route->id} ({$route->osmfeatures_id}) - updated ({$actions}) (osm2cai_status={$route->osm2cai_status})");
@@ -373,6 +411,43 @@ class ForceUpdateOsmFeaturesFromTo extends Command
             ]
         );
 
-        $logger->info("ForceUpdateOsmFeaturesFromTo: end - processed={$this->processed}, updated={$this->updated}, skipped={$this->skipped}, errors={$this->errors}, dry-run={$this->isDryRun}, details={$this->isDetails}");
+        $logger->info("ForceUpdateOsmFeaturesFromTo: end - processed={$this->processed}, updated={$this->updated}, skipped={$this->skipped}, errors={$this->errors}, dry-run={$this->isDryRun}, details={$this->isDetails}, update-name={$this->shouldUpdateName}");
+    }
+
+    private function decodeOsmfeaturesData(mixed $osmfeaturesData): ?array
+    {
+        if (is_array($osmfeaturesData)) {
+            return $osmfeaturesData;
+        }
+
+        if (is_string($osmfeaturesData)) {
+            $decoded = json_decode($osmfeaturesData, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return null;
+    }
+
+    private function needsFetchFromApi(HikingRoute $route): bool
+    {
+        $properties = is_array($route->properties) ? $route->properties : [];
+        $localFrom = $properties['from'] ?? null;
+        $localTo = $properties['to'] ?? null;
+
+        if (! $this->isEmptyValue($localFrom) && ! $this->isEmptyValue($localTo)) {
+            return false;
+        }
+
+        $osmfeaturesData = $this->decodeOsmfeaturesData($route->osmfeatures_data);
+        $props = is_array($osmfeaturesData) ? ($osmfeaturesData['properties'] ?? []) : [];
+        $osfFrom = is_array($props) ? ($props['from'] ?? null) : null;
+        $osfTo = is_array($props) ? ($props['to'] ?? null) : null;
+
+        $needsFrom = $this->isEmptyValue($localFrom) && $this->isEmptyValue($osfFrom);
+        $needsTo = $this->isEmptyValue($localTo) && $this->isEmptyValue($osfTo);
+
+        return $needsFrom || $needsTo;
     }
 }

--- a/tests/Unit/Commands/ForceUpdateOsmFeaturesFromToCommandTest.php
+++ b/tests/Unit/Commands/ForceUpdateOsmFeaturesFromToCommandTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Tests\Unit\Commands;
+
+use App\Console\Commands\ForceUpdateOsmFeaturesFromTo;
+use App\Models\HikingRoute;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+use Wm\WmPackage\Jobs\Track\UpdateEcTrackAwsJob;
+
+class ForceUpdateOsmFeaturesFromToCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Disabilita Scout completamente per evitare connessioni a Elasticsearch
+        config(['scout.driver' => null]);
+
+        Queue::fake();
+
+        // Registra esplicitamente il comando nel kernel dei test (senza toccare App\Console\Kernel)
+        /** @var \Illuminate\Foundation\Console\Kernel $kernel */
+        $kernel = $this->app->make(\Illuminate\Contracts\Console\Kernel::class);
+        $kernel->addCommands([ForceUpdateOsmFeaturesFromTo::class]);
+
+        // Crea le colonne osmfeatures se non esistono (ambiente test può avere schema non allineato)
+        if (! Schema::hasColumn('hiking_routes', 'osmfeatures_id')) {
+            DB::statement('ALTER TABLE hiking_routes ADD COLUMN osmfeatures_id varchar(255)');
+        }
+        if (! Schema::hasColumn('hiking_routes', 'osmfeatures_data')) {
+            DB::statement('ALTER TABLE hiking_routes ADD COLUMN osmfeatures_data jsonb');
+        }
+        if (! Schema::hasColumn('hiking_routes', 'osmfeatures_updated_at')) {
+            DB::statement('ALTER TABLE hiking_routes ADD COLUMN osmfeatures_updated_at timestamp');
+        }
+        if (! Schema::hasColumn('hiking_routes', 'properties')) {
+            DB::statement('ALTER TABLE hiking_routes ADD COLUMN properties jsonb');
+        }
+    }
+
+    private function createHikingRoute(
+        string $osmfeaturesId,
+        array $properties,
+        array $osmfeaturesData
+    ): HikingRoute {
+        return HikingRoute::factory()->createQuietly([
+            'osmfeatures_id' => $osmfeaturesId,
+            'osm2cai_status' => 4,
+            'properties' => $properties,
+            'osmfeatures_data' => $osmfeaturesData,
+            'osmfeatures_updated_at' => Carbon::now()->subDay(),
+            'geometry' => DB::raw("ST_GeomFromText('MULTILINESTRINGZ((1 1 0, 2 2 0))', 4326)"),
+            'geometry_raw_data' => DB::raw("ST_GeomFromText('MULTILINESTRINGZ((1 1 0, 2 2 0))', 4326)"),
+            'is_geometry_correct' => true,
+        ]);
+    }
+
+    private function fakeSingleFeature(string $osmfeaturesId, ?string $from, ?string $to): void
+    {
+        $endpoint = HikingRoute::getOsmfeaturesEndpoint();
+
+        Http::fake([
+            $endpoint.$osmfeaturesId => Http::response([
+                'type' => 'Feature',
+                'geometry' => null,
+                'properties' => [
+                    'from' => $from,
+                    'to' => $to,
+                ],
+            ], 200),
+        ]);
+    }
+
+    /** @test */
+    public function it_does_not_persist_changes_in_dry_run(): void
+    {
+        $osmfeaturesId = 'R12345678';
+
+        $route = $this->createHikingRoute(
+            $osmfeaturesId,
+            ['from' => '', 'to' => ''],
+            ['properties' => ['from' => '', 'to' => '']]
+        );
+
+        $this->fakeSingleFeature($osmfeaturesId, 'A', 'B');
+
+        $this->artisan('osm2cai:force-update-osmfeatures-from-to', [
+            '--dry-run' => true,
+            '--id' => $route->id,
+            '--delay' => 0,
+        ])->assertSuccessful();
+
+        $route->refresh();
+        $this->assertSame('', $route->properties['from'] ?? '');
+        $this->assertSame('', $route->properties['to'] ?? '');
+        $this->assertSame('', $route->osmfeatures_data['properties']['from'] ?? '');
+        $this->assertSame('', $route->osmfeatures_data['properties']['to'] ?? '');
+
+        Queue::assertNotPushed(UpdateEcTrackAwsJob::class);
+    }
+
+    /** @test */
+    public function it_updates_properties_and_osmfeatures_data_and_dispatches_aws_job(): void
+    {
+        $osmfeaturesId = 'R12345679';
+
+        $route = $this->createHikingRoute(
+            $osmfeaturesId,
+            ['from' => '', 'to' => ''],
+            ['properties' => ['ref' => 'REF001', 'from' => '', 'to' => '']]
+        );
+
+        $this->fakeSingleFeature($osmfeaturesId, 'From API', 'To API');
+
+        $this->artisan('osm2cai:force-update-osmfeatures-from-to', [
+            '--id' => $route->id,
+            '--delay' => 0,
+        ])->assertSuccessful();
+
+        $route->refresh();
+
+        $this->assertSame('From API', $route->properties['from']);
+        $this->assertSame('To API', $route->properties['to']);
+        $this->assertSame('From API', $route->osmfeatures_data['properties']['from']);
+        $this->assertSame('To API', $route->osmfeatures_data['properties']['to']);
+        $this->assertSame('REF001 - From API - To API', $route->name);
+
+        Queue::assertPushed(UpdateEcTrackAwsJob::class);
+    }
+
+    /** @test */
+    public function it_does_not_overwrite_non_empty_local_values_with_empty_api_values(): void
+    {
+        $osmfeaturesId = 'R12345680';
+
+        $route = $this->createHikingRoute(
+            $osmfeaturesId,
+            ['from' => 'LOCAL', 'to' => ''],
+            ['properties' => ['from' => '', 'to' => '']]
+        );
+
+        // API returns empty from, valid to
+        $this->fakeSingleFeature($osmfeaturesId, '', 'DEST');
+
+        $this->artisan('osm2cai:force-update-osmfeatures-from-to', [
+            '--id' => $route->id,
+            '--delay' => 0,
+        ])->assertSuccessful();
+
+        $route->refresh();
+
+        // 'from' local already set, should stay
+        $this->assertSame('LOCAL', $route->properties['from']);
+        // 'to' should be filled
+        $this->assertSame('DEST', $route->properties['to']);
+
+        // hybrid: osmfeatures_data should get 'to' (and 'from' stays empty because api empty)
+        $this->assertSame('', $route->osmfeatures_data['properties']['from'] ?? '');
+        $this->assertSame('DEST', $route->osmfeatures_data['properties']['to']);
+
+        Queue::assertPushed(UpdateEcTrackAwsJob::class);
+    }
+}
+

--- a/tests/Unit/Commands/ForceUpdateOsmFeaturesFromToCommandTest.php
+++ b/tests/Unit/Commands/ForceUpdateOsmFeaturesFromToCommandTest.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
-use Wm\WmPackage\Jobs\Track\UpdateEcTrackAwsJob;
 
 class ForceUpdateOsmFeaturesFromToCommandTest extends TestCase
 {
@@ -49,11 +48,13 @@ class ForceUpdateOsmFeaturesFromToCommandTest extends TestCase
     private function createHikingRoute(
         string $osmfeaturesId,
         array $properties,
-        array $osmfeaturesData
+        array $osmfeaturesData,
+        string $name = 'OLD NAME'
     ): HikingRoute {
         return HikingRoute::factory()->createQuietly([
             'osmfeatures_id' => $osmfeaturesId,
             'osm2cai_status' => 4,
+            'name' => $name,
             'properties' => $properties,
             'osmfeatures_data' => $osmfeaturesData,
             'osmfeatures_updated_at' => Carbon::now()->subDay(),
@@ -104,18 +105,19 @@ class ForceUpdateOsmFeaturesFromToCommandTest extends TestCase
         $this->assertSame('', $route->osmfeatures_data['properties']['from'] ?? '');
         $this->assertSame('', $route->osmfeatures_data['properties']['to'] ?? '');
 
-        Queue::assertNotPushed(UpdateEcTrackAwsJob::class);
+        Queue::assertNothingPushed();
     }
 
     /** @test */
-    public function it_updates_properties_and_osmfeatures_data_and_dispatches_aws_job(): void
+    public function it_updates_properties_and_osmfeatures_data_quietly_and_does_not_update_name_by_default(): void
     {
         $osmfeaturesId = 'R12345679';
 
         $route = $this->createHikingRoute(
             $osmfeaturesId,
             ['from' => '', 'to' => ''],
-            ['properties' => ['ref' => 'REF001', 'from' => '', 'to' => '']]
+            ['properties' => ['ref' => 'REF001', 'from' => '', 'to' => '']],
+            'OLD NAME'
         );
 
         $this->fakeSingleFeature($osmfeaturesId, 'From API', 'To API');
@@ -131,9 +133,9 @@ class ForceUpdateOsmFeaturesFromToCommandTest extends TestCase
         $this->assertSame('To API', $route->properties['to']);
         $this->assertSame('From API', $route->osmfeatures_data['properties']['from']);
         $this->assertSame('To API', $route->osmfeatures_data['properties']['to']);
-        $this->assertSame('REF001 - From API - To API', $route->name);
+        $this->assertSame('OLD NAME', $route->name);
 
-        Queue::assertPushed(UpdateEcTrackAwsJob::class);
+        Queue::assertNothingPushed();
     }
 
     /** @test */
@@ -166,7 +168,56 @@ class ForceUpdateOsmFeaturesFromToCommandTest extends TestCase
         $this->assertSame('', $route->osmfeatures_data['properties']['from'] ?? '');
         $this->assertSame('DEST', $route->osmfeatures_data['properties']['to']);
 
-        Queue::assertPushed(UpdateEcTrackAwsJob::class);
+        Queue::assertNothingPushed();
+    }
+
+    /** @test */
+    public function it_updates_properties_from_osmfeatures_data_without_calling_api(): void
+    {
+        $osmfeaturesId = 'R12345681';
+
+        $route = $this->createHikingRoute(
+            $osmfeaturesId,
+            ['from' => '', 'to' => ''],
+            ['properties' => ['from' => 'FROM OSF', 'to' => 'TO OSF']]
+        );
+
+        Http::fake();
+
+        $this->artisan('osm2cai:force-update-osmfeatures-from-to', [
+            '--id' => $route->id,
+            '--delay' => 0,
+        ])->assertSuccessful();
+
+        $route->refresh();
+        $this->assertSame('FROM OSF', $route->properties['from']);
+        $this->assertSame('TO OSF', $route->properties['to']);
+
+        Http::assertNothingSent();
+    }
+
+    /** @test */
+    public function it_updates_name_only_when_option_is_enabled(): void
+    {
+        $osmfeaturesId = 'R12345682';
+
+        $route = $this->createHikingRoute(
+            $osmfeaturesId,
+            ['from' => '', 'to' => ''],
+            ['properties' => ['ref' => 'REF001', 'from' => '', 'to' => '']],
+            'OLD NAME'
+        );
+
+        $this->fakeSingleFeature($osmfeaturesId, 'From API', 'To API');
+
+        $this->artisan('osm2cai:force-update-osmfeatures-from-to', [
+            '--id' => $route->id,
+            '--delay' => 0,
+            '--update-name' => true,
+        ])->assertSuccessful();
+
+        $route->refresh();
+        $this->assertSame('REF001 - From API - To API', $route->name);
     }
 }
 


### PR DESCRIPTION
- Introduced a new console command `ForceUpdateOsmFeaturesFromTo` to forcefully update 'from' and 'to' properties in HikingRoute models using data from osmfeatures.
- Supports options for dry run, batch size, delay between requests, timeout, and limit on the number of routes processed.
- Implements concurrent HTTP requests to fetch data and logs detailed processing information.
- Enhances error handling for HTTP requests and response validation.

feat(command): ✨ enhance ForceUpdateOsmFeaturesFromTo to update osmfeatures_data properties

- Added logic to update 'from' and 'to' properties in the osmfeatures_data of HikingRoute models if they are empty and new values are available from the API.
- Improved the update mechanism to include changes to osmfeatures_data alongside existing properties.
- Enhanced logging to provide detailed information on updates made to both properties and osmfeatures_data.

feat(command): ✨ add ID option to ForceUpdateOsmFeaturesFromTo command and implement unit tests

- Introduced an `--id` option to the `ForceUpdateOsmFeaturesFromTo` command for processing specific HikingRoute entries, aiding in testing and debugging.
- Enhanced logging to include the ID of the processed HikingRoute.
- Added comprehensive unit tests for the command, covering scenarios such as dry runs, property updates, and ensuring local values are not overwritten by empty API responses.

feat(command): ✨ enhance ForceUpdateOsmFeaturesFromTo to update route name based on properties

- Added logic to update the name of HikingRoute models when 'from', 'to', and 'ref' properties are modified.
- The new name format is now 'ref - from - to' if both 'from' and 'to' are available.
- Updated unit tests to verify the correct name assignment based on the new logic.
