### PR TITLE
feat: enhance user role permissions for SICAI OC: 7784

### DIFF
--- a/app/Nova/SiPoi.php
+++ b/app/Nova/SiPoi.php
@@ -3,15 +3,18 @@
 namespace App\Nova;
 
 use App\Enums\SicaiSituazioneEnum;
-use App\Nova\Filters\SicaiSituazioneFilter;
+use App\Enums\UserRole;
 use App\Models\SiPoi as SiPoiModel;
-use Wm\WmPackage\Nova\Actions\RegenerateEcPoiTaxonomyWhere;
+use App\Models\User as UserModel;
+use App\Nova\Filters\SicaiSituazioneFilter;
 use Ebess\AdvancedNovaMediaLibrary\Fields\Images;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Schema;
 use Kongulov\NovaTabTranslatable\NovaTabTranslatable;
 use Laravel\Nova\Fields\BelongsToMany;
 use Laravel\Nova\Fields\Boolean;
-use Laravel\Nova\Fields\FormData;
+
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
@@ -19,8 +22,9 @@ use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Tabs\Tab;
 use Marshmallow\Tiptap\Tiptap;
 use Wm\MapPoint\MapPoint;
-use Wm\WmPackage\Nova\Fields\PropertiesPanel;
+use Wm\WmPackage\Nova\Actions\RegenerateEcPoiTaxonomyWhere;
 use Wm\WmPackage\Nova\Fields\FeatureCollectionMap\src\FeatureCollectionMap;
+use Wm\WmPackage\Nova\Fields\PropertiesPanel;
 
 class SiPoi extends EcPoi
 {
@@ -48,12 +52,29 @@ class SiPoi extends EcPoi
     }
 
     /**
-     * Limita l’index agli EC provenienti da pt_accoglienza_unofficial (app_id = 2).
+     * Restrict the index to EC POIs coming from pt_accoglienza_unofficial (app_id = 2).
+     *
+     * Replicates the logic of Wm\WmPackage\Nova\AbstractEcResource::indexQuery
+     * (filters by user_id when the user is not Administrator) but also exempts
+     * users with the SicaiManager role from the filter: they must be able to
+     * see all Sentiero Italia CAI Welcome Points, not just the ones they
+     * created themselves.
      */
     public static function indexQuery(NovaRequest $request, $query): Builder
     {
         /** @var Builder $query */
-        $query = parent::indexQuery($request, $query);
+        /** @var UserModel|null $user */
+        $user = Auth::user();
+
+        if ($user
+            && ! $user->hasRole(UserRole::Administrator->value)
+            && ! $user->hasRole(UserRole::SicaiManager->value)
+        ) {
+            $table = $query->getModel()->getTable();
+            if (Schema::hasColumn($table, 'user_id')) {
+                $query->where('user_id', $user->id);
+            }
+        }
 
         return $query
             ->where('app_id', 2)

--- a/app/Policies/SiHikingRoutePolicy.php
+++ b/app/Policies/SiHikingRoutePolicy.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\UserRole;
+use App\Models\SiHikingRoute;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+/**
+ * Policy for the Sentiero Italia CAI hiking routes.
+ *
+ * Without this policy, Laravel would automatically resolve HikingRoutePolicy
+ * (because SiHikingRoute extends HikingRoute), which prevents any modification
+ * for non-Administrator users. Here, besides Administrators (handled by
+ * before()), users with the SicaiManager role are also authorized to view and
+ * edit Sentiero Italia content.
+ */
+class SiHikingRoutePolicy
+{
+    use HandlesAuthorization;
+
+    public function before(User $user, string $ability)
+    {
+        if ($user->hasRole(UserRole::Administrator)) {
+            return true;
+        }
+    }
+
+    protected function isSicaiManager(User $user): bool
+    {
+        return $user->hasRole(UserRole::SicaiManager);
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function view(User $user, SiHikingRoute $siHikingRoute): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function create(User $user): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function update(User $user, SiHikingRoute $siHikingRoute): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function delete(User $user, SiHikingRoute $siHikingRoute): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function restore(User $user, SiHikingRoute $siHikingRoute): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function forceDelete(User $user, SiHikingRoute $siHikingRoute): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+}

--- a/app/Policies/SiMTBRoutePolicy.php
+++ b/app/Policies/SiMTBRoutePolicy.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\UserRole;
+use App\Models\SiMTBRoute;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+/**
+ * Policy for the Sentiero Italia CAI MTB routes.
+ *
+ * Without this policy, Laravel would automatically resolve HikingRoutePolicy
+ * (because SiMTBRoute extends HikingRoute), which prevents any modification
+ * for non-Administrator users. Here, besides Administrators (handled by
+ * before()), users with the SicaiManager role are also authorized to view and
+ * edit Sentiero Italia content.
+ */
+class SiMTBRoutePolicy
+{
+    use HandlesAuthorization;
+
+    public function before(User $user, string $ability)
+    {
+        if ($user->hasRole(UserRole::Administrator)) {
+            return true;
+        }
+    }
+
+    protected function isSicaiManager(User $user): bool
+    {
+        return $user->hasRole(UserRole::SicaiManager);
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function view(User $user, SiMTBRoute $siMTBRoute): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function create(User $user): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function update(User $user, SiMTBRoute $siMTBRoute): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function delete(User $user, SiMTBRoute $siMTBRoute): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function restore(User $user, SiMTBRoute $siMTBRoute): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function forceDelete(User $user, SiMTBRoute $siMTBRoute): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+}

--- a/app/Policies/SiPoiPolicy.php
+++ b/app/Policies/SiPoiPolicy.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\UserRole;
+use App\Models\SiPoi;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+/**
+ * Policy for the Sentiero Italia CAI Welcome Points.
+ *
+ * Without this policy, Laravel would not resolve any specific policy for
+ * SiPoi (auto-discovery of App\Models\EcPoi does not propagate to subclasses).
+ * Here, besides Administrators (handled by before()), users with the
+ * SicaiManager role are also authorized to view and edit Sentiero Italia
+ * content.
+ */
+class SiPoiPolicy
+{
+    use HandlesAuthorization;
+
+    public function before(User $user, string $ability)
+    {
+        if ($user->hasRole(UserRole::Administrator)) {
+            return true;
+        }
+    }
+
+    protected function isSicaiManager(User $user): bool
+    {
+        return $user->hasRole(UserRole::SicaiManager);
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function view(User $user, SiPoi $siPoi): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function create(User $user): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function update(User $user, SiPoi $siPoi): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function delete(User $user, SiPoi $siPoi): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function restore(User $user, SiPoi $siPoi): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+
+    public function forceDelete(User $user, SiPoi $siPoi): bool
+    {
+        return $this->isSicaiManager($user);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -17,6 +17,14 @@ class AuthServiceProvider extends ServiceProvider
         \App\Models\HikingRoute::class => \App\Policies\HikingRoutePolicy::class,
         \App\Models\SignageProject::class => \App\Policies\SignageProjectPolicy::class,
         \App\Models\TrailSurvey::class => \App\Policies\TrailSurveyPolicy::class,
+        // Policies for the Sentiero Italia CAI content must be declared
+        // explicitly: SiHikingRoute and SiMTBRoute extend HikingRoute, and
+        // without an explicit mapping Laravel would resolve HikingRoutePolicy
+        // via is_subclass_of, preventing the SicaiManager role from making
+        // any modifications.
+        \App\Models\SiHikingRoute::class => \App\Policies\SiHikingRoutePolicy::class,
+        \App\Models\SiMTBRoute::class => \App\Policies\SiMTBRoutePolicy::class,
+        \App\Models\SiPoi::class => \App\Policies\SiPoiPolicy::class,
         \Wm\WmPackage\Models\TaxonomyPoiType::class => \Wm\WmPackage\Policies\TaxonomyPoiTypePolicy::class,
         \Wm\WmPackage\Models\TaxonomyActivity::class => \Wm\WmPackage\Policies\TaxonomyActivityPolicy::class,
     ];

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Enums\UserRole;
+use App\Models\User as UserModel;
 use App\Nova\App;
 use App\Nova\ArchaeologicalArea;
 use App\Nova\ArchaeologicalSite;
@@ -34,14 +35,14 @@ use App\Nova\Region;
 use App\Nova\Sector;
 use App\Nova\Sign;
 use App\Nova\SignageProject;
+use App\Nova\SiHikingRoute;
+use App\Nova\SiMTBRoute;
+use App\Nova\SiPoi;
 use App\Nova\SourceSurvey;
 use App\Nova\TaxonomyActivity;
 use App\Nova\TaxonomyPoiType;
 use App\Nova\TaxonomyWhere;
 use App\Nova\TrailSurvey;
-use App\Nova\SiHikingRoute;
-use App\Nova\SiMTBRoute;
-use App\Nova\SiPoi;
 use App\Nova\UgcMedia;
 use App\Nova\UgcPoi;
 use App\Nova\UgcTrack;
@@ -72,8 +73,26 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
         Nova::style('custom-fields-css', public_path('css/custom-nova.css'));
 
         Nova::mainMenu(function (Request $request) {
+            // Check if the user is a Sicai Manager
+            $isSicaiManagerOnly = function () {
+                /** @var UserModel|null $user */
+                $user = Auth::user();
+
+                if (! $user) {
+                    return false;
+                }
+
+                return $user->hasRole(UserRole::SicaiManager)
+                    && ! $user->hasRole(UserRole::Administrator)
+                    && $user->email !== 'team@webmapp.it';
+            };
+
+            $hideForSicaiManager = function () use ($isSicaiManagerOnly) {
+                return ! $isSicaiManagerOnly();
+            };
+
             return [
-                MenuSection::dashboard(Main::class)->icon('home'),
+                MenuSection::dashboard(Main::class)->icon('home')->canSee($hideForSicaiManager),
                 // Admin
                 MenuSection::make(__('Admin'), [
                     MenuItem::resource(User::class, __('User'))->canSee(function () {
@@ -146,7 +165,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                         ->canSee(function () {
                             return optional(Auth::user())->hasRole(UserRole::RegionalReferent);
                         }),
-                ])->icon('chart-bar')->collapsable()->collapsedByDefault(),
+                ])->icon('chart-bar')->collapsable()->collapsedByDefault()->canSee($hideForSicaiManager),
 
                 // Rete Escursionistica
                 MenuSection::make(__('Rete Escursionistica'), [
@@ -166,14 +185,15 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                         MenuItem::resource(Province::class, __('Provinces')),
                         MenuItem::resource(Region::class, __('Regions')),
                     ])->icon('none')->collapsable()->collapsedByDefault(),
-                ])->icon('globe')->collapsable(),
+                ])->icon('globe')->collapsable()->canSee($hideForSicaiManager),
 
-                // Sentiero Italia CAI (solo utenti con ruolo Sicai Manager)
+                // Sentiero Italia CAI (only for users with the Sicai Manager role)
                 MenuSection::make(__('Sentiero Italia CAI'), [
                     MenuItem::resource(SiHikingRoute::class, __('Hiking Routes')),
                     MenuItem::resource(SiMTBRoute::class, __('MTB Routes')),
                     MenuItem::resource(SiPoi::class, __('SI Pois')),
                 ])->icon('map')->collapsable()->collapsedByDefault()->canSee(function () {
+                    /** @var UserModel|null $user */
                     $user = Auth::user();
 
                     if (! $user) {
@@ -190,7 +210,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                     MenuItem::resource(MountainGroups::class, __('Mountain Groups')),
                     MenuItem::resource(CaiHut::class, __('Huts')),
                     MenuItem::resource(NaturalSpring::class, __('Acqua Sorgente')),
-                ])->icon('database')->collapsable()->collapsedByDefault(),
+                ])->icon('database')->collapsable()->collapsedByDefault()->canSee($hideForSicaiManager),
 
                 // Rilievi
                 MenuSection::make(__('Rilievi'), [
@@ -207,12 +227,12 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                         MenuItem::resource(ArchaeologicalArea::class),
                         MenuItem::resource(GeologicalSite::class),
                     ])->icon('none')->collapsable()->collapsedByDefault(),
-                ])->icon('eye')->collapsable(),
+                ])->icon('eye')->collapsable()->canSee($hideForSicaiManager),
                 MenuSection::make(__('Webapp'), [
-                    MenuItem::externalLink(__('App del Sentierista'), 'http://1.osm2cai.cai.it/')->openInNewTab(),
+                    MenuItem::externalLink(__('App del Sentierista'), 'http://1.osm2cai.cai.it/')->openInNewTab()->canSee($hideForSicaiManager),
                     MenuItem::externalLink(__('Sicai'), 'http://2.osm2cai.cai.it/')->openInNewTab(),
-                    MenuItem::externalLink(__('Acqua Sorgente'), 'http://3.osm2cai.cai.it/')->openInNewTab(),
-                    MenuItem::externalLink(__('INFOMONT'), 'https://infomont.cai.it')->openInNewTab(),
+                    MenuItem::externalLink(__('Acqua Sorgente'), 'http://3.osm2cai.cai.it/')->openInNewTab()->canSee($hideForSicaiManager),
+                    MenuItem::externalLink(__('INFOMONT'), 'https://infomont.cai.it')->openInNewTab()->canSee($hideForSicaiManager),
                 ])->icon('map')->collapsable()->collapsedByDefault(),
                 // Tools
                 MenuSection::make(__('Tools'), [
@@ -222,7 +242,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                     MenuItem::externalLink(__('Migration check'), route('migration-check'))->canSee(function () {
                         return optional(Auth::user())->hasRole(UserRole::Administrator);
                     })->openInNewTab(),
-                ])->icon('color-swatch')->collapsable()->collapsedByDefault(),
+                ])->icon('color-swatch')->collapsable()->collapsedByDefault()->canSee($hideForSicaiManager),
 
             ];
         });
@@ -274,7 +294,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
             return $dashboards;
         }
 
-        /** @var \App\Models\User $loggedInUser */
+        /** @var UserModel $loggedInUser */
         if (method_exists($loggedInUser, 'hasRole') && $loggedInUser->hasRole(UserRole::Administrator)) {
             $dashboards[] = new Utenti;
             $dashboards[] = new Percorribilità;

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -236,13 +236,13 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                 ])->icon('map')->collapsable()->collapsedByDefault(),
                 // Tools
                 MenuSection::make(__('Tools'), [
-                    MenuItem::externalLink(__('LoScarpone-Export'), route('loscarpone-export'))->openInNewTab(),
-                    MenuItem::externalLink(__('API'), '/api/documentation')->openInNewTab(),
+                    MenuItem::externalLink(__('LoScarpone-Export'), route('loscarpone-export'))->openInNewTab()->canSee($hideForSicaiManager),
+                    MenuItem::externalLink(__('API'), '/api/documentation')->openInNewTab()->canSee($hideForSicaiManager),
                     MenuItem::externalLink(__('Documentazione OSM2CAI'), 'https://catastorei.gitbook.io/documentazione-osm2cai')->openInNewTab(),
                     MenuItem::externalLink(__('Migration check'), route('migration-check'))->canSee(function () {
                         return optional(Auth::user())->hasRole(UserRole::Administrator);
                     })->openInNewTab(),
-                ])->icon('color-swatch')->collapsable()->collapsedByDefault()->canSee($hideForSicaiManager),
+                ])->icon('color-swatch')->collapsable()->collapsedByDefault(),
 
             ];
         });


### PR DESCRIPTION
Integrates SicaiManager role into policies, allowing broader access to Sentiero Italia CAI resources. Updates indexQuery to exempt SicaiManagers from user_id restrictions, aligning functionalities with administrative roles while maintaining role-specific visibility. Introduces new policies for SiHikingRoute, SiMTBRoute, and SiPoi to enable role-specific content management and explicit policy declaration in AuthServiceProvider.