### PR TITLE
feat: add Tile resource and migrations for tiles and app_tile oc:7657

### DIFF
--- a/app/Nova/Tile.php
+++ b/app/Nova/Tile.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Nova;
+
+use Wm\WmPackage\Nova\Tile as WmNovaTile;
+
+class Tile extends WmNovaTile {}
+

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -38,6 +38,7 @@ use App\Nova\SourceSurvey;
 use App\Nova\TaxonomyActivity;
 use App\Nova\TaxonomyPoiType;
 use App\Nova\TaxonomyWhere;
+use App\Nova\Tile;
 use App\Nova\TrailSurvey;
 use App\Nova\SiHikingRoute;
 use App\Nova\SiMTBRoute;
@@ -86,7 +87,10 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                         return optional(Auth::user())->hasRole(UserRole::Administrator);
                     }),
                     MenuSection::make(__('MOBILE'), [
-                        MenuItem::resource(App::class),
+                        MenuSection::make(__('Apps'), [
+                            MenuItem::resource(App::class),
+                            MenuItem::resource(Tile::class),
+                        ])->icon('none')->collapsable()->collapsedByDefault(),
                         MenuItem::resource(WmUser::class),
                         MenuSection::make(__('Editorial Content'), [
                             MenuItem::resource(Layer::class),

--- a/database/migrations/2026_05_06_120451_zz_2026_04_23_120000_create_tiles_table.php
+++ b/database/migrations/2026_05_06_120451_zz_2026_04_23_120000_create_tiles_table.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tiles', function (Blueprint $table) {
+            $table->id();
+            $table->string('attribution')->unique();
+            $table->json('label');
+            $table->string('icon')->nullable();
+            $table->string('server_xyz');
+            $table->string('link')->nullable();
+            $table->timestamps();
+        });
+
+        $now = now();
+
+        DB::table('tiles')->updateOrInsert(
+            ['attribution' => 'webmapp'],
+            [
+                'label' => json_encode(['it' => 'Webmapp', 'en' => 'Webmapp'], JSON_UNESCAPED_UNICODE),
+                'icon' => "tile-default",
+                'server_xyz' => 'https://api.webmapp.it/tiles/{z}/{x}/{y}.png',
+                'link' => "https://webmapp.it/",
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]
+        );
+
+        DB::table('tiles')->updateOrInsert(
+            ['attribution' => 'mute'],
+            [
+                'label' => json_encode(['it' => 'Mute', 'en' => 'Mute'], JSON_UNESCAPED_UNICODE),
+                'icon' => "tile-mute",
+                'server_xyz' => 'http://tiles.webmapp.it/blankmap/{z}/{x}/{y}.png',
+                'link' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]
+        );
+
+        DB::table('tiles')->updateOrInsert(
+            ['attribution' => 'satellite'],
+            [
+                'label' => json_encode(['it' => 'Satellite', 'en' => 'Satellite'], JSON_UNESCAPED_UNICODE),
+                'icon' => "tile-satellite",
+                'server_xyz' => 'https://api.maptiler.com/tiles/satellite/{z}/{x}/{y}.jpg?key=0Z7ou7nfFFXipdDXHChf',
+                'link' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]
+        );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tiles');
+    }
+};
+

--- a/database/migrations/2026_05_06_120452_zz_2026_04_23_120100_create_app_tile_table.php
+++ b/database/migrations/2026_05_06_120452_zz_2026_04_23_120100_create_app_tile_table.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('app_tile', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('app_id')
+                ->constrained('apps')
+                ->cascadeOnDelete();
+            $table->foreignId('tile_id')
+                ->constrained('tiles')
+                ->cascadeOnDelete();
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->unique(['app_id', 'tile_id']);
+            $table->index(['app_id', 'sort_order']);
+        });
+
+        // Backfill dalla colonna JSON `apps.tiles` mantenendo l'ordine originale.
+        // Format atteso per ogni elemento JSON-string: {"attribution": "server_xyz_url"}
+        $tilesByAttribution = DB::table('tiles')->pluck('id', 'attribution');
+        $now = now();
+
+        $apps = DB::table('apps')->select('id', 'tiles')->get();
+        foreach ($apps as $app) {
+            $raw = $app->tiles;
+            if (empty($raw)) {
+                continue;
+            }
+
+            $list = json_decode($raw, true);
+            if (! is_array($list)) {
+                continue;
+            }
+
+            $order = 0;
+            foreach ($list as $entry) {
+                $decoded = is_string($entry) ? json_decode($entry, true) : $entry;
+                if (! is_array($decoded) || empty($decoded)) {
+                    continue;
+                }
+
+                $attribution = (string) array_key_first($decoded);
+                $tileId = $tilesByAttribution[$attribution] ?? null;
+                if (! $tileId) {
+                    continue;
+                }
+
+                DB::table('app_tile')->updateOrInsert(
+                    ['app_id' => $app->id, 'tile_id' => $tileId],
+                    ['sort_order' => $order, 'created_at' => $now, 'updated_at' => $now]
+                );
+
+                $order++;
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('app_tile');
+    }
+};
+


### PR DESCRIPTION
- Introduced a new Tile resource in Nova, extending from WmNovaTile.
- Created migration for the tiles table, including default entries for various tile types.
- Added migration for the app_tile table to establish relationships between apps and tiles, with backfilling logic for existing data.
