### PR TITLE
feat(si_poi): add default taxonomy type on creation OC:7786

### DIFF
--- a/app/Models/SiPoi.php
+++ b/app/Models/SiPoi.php
@@ -3,13 +3,15 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Wm\WmPackage\Models\EcTrack;
 use Wm\WmPackage\Models\EcPoiEcTrack;
-use App\Models\SiHikingRoute;
+use Wm\WmPackage\Models\EcTrack;
+use Wm\WmPackage\Models\TaxonomyPoiType;
 
 class SiPoi extends EcPoi
 {
     protected $table = 'ec_pois';
+
+    public const DEFAULT_TAXONOMY_POI_TYPE_IDENTIFIER = 'punto-accoglienza';
 
     protected static function boot()
     {
@@ -34,6 +36,21 @@ class SiPoi extends EcPoi
             $properties['sicai'] = $sicai;
             $model->properties = $properties;
         });
+
+        static::created(function (self $model): void {
+            if ($model->taxonomyPoiTypes()->exists()) {
+                return;
+            }
+
+            $taxonomyPoiType = TaxonomyPoiType::where(
+                'identifier',
+                self::DEFAULT_TAXONOMY_POI_TYPE_IDENTIFIER
+            )->first();
+
+            if ($taxonomyPoiType !== null) {
+                $model->taxonomyPoiTypes()->attach($taxonomyPoiType->id);
+            }
+        });
     }
 
     /**
@@ -45,7 +62,6 @@ class SiPoi extends EcPoi
     {
         return EcPoi::class;
     }
-
 
     public function ecTracks(): BelongsToMany
     {

--- a/tests/Unit/Models/SiPoiTaxonomyTest.php
+++ b/tests/Unit/Models/SiPoiTaxonomyTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\SiPoi;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+use Wm\WmPackage\Models\TaxonomyPoiType;
+
+class SiPoiTaxonomyTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
+    /** @test */
+    public function it_attaches_punto_accoglienza_taxonomy_poi_type_on_create(): void
+    {
+        $taxonomyPoiType = TaxonomyPoiType::firstOrCreate(
+            ['identifier' => SiPoi::DEFAULT_TAXONOMY_POI_TYPE_IDENTIFIER],
+            [
+                'name' => ['it' => 'Punto Accoglienza'],
+                'description' => [],
+                'excerpt' => [],
+                'icon' => 'txn-alpine-hut',
+            ]
+        );
+
+        $siPoi = SiPoi::create([
+            'name' => ['it' => 'Test Welcome Point'],
+            'geometry' => DB::raw("ST_GeomFromText('POINTZ(12.5 41.9 0)', 4326)"),
+        ]);
+
+        $this->assertTrue(
+            $siPoi->taxonomyPoiTypes()
+                ->where('taxonomy_poi_types.id', $taxonomyPoiType->id)
+                ->exists()
+        );
+        $this->assertSame(2, $siPoi->fresh()->app_id);
+    }
+}


### PR DESCRIPTION
Automatically attaches 'punto-accoglienza' taxonomy type when a SiPoi model is created, ensuring new entries have a default taxonomy classification if none is specified. Adds unit test to verify this behavior, addressing ticket OC-7786.