### PR TITLE
feat: add command for SiHikingRoute data cleanup OC:7954

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,19 @@ I job in `app/Jobs/` gestiscono operazioni asincrone:
 - `GeoBufferTrait` per operazioni di buffer di prossimità
 - Utilità di conversione geometria in `app/Services/GeometryService.php`
 
+## Decisioni architetturali
+
+### Cleanup manual_data SiHikingRoute (oc:7954)
+- Nei command che modificano record durante l'iterazione usare sempre `chunkById()` invece di `chunk()`: `chunk()` usa LIMIT/OFFSET e salta record quando la result set cambia sotto di lui.
+- L'operatore `?` di PostgreSQL (esistenza chiave JSONB) va scritto `??` dentro `whereRaw()` per evitare che PDO lo interpreti come placeholder di bind.
+- `--verbose` è riservato da Symfony Console: usare `$this->output->isVerbose()` attivato dal flag nativo `-v` invece di dichiarare un'opzione custom.
+
+## Feature disponibili
+
+| Feature | Ticket | Moduli toccati | Note |
+|---|---|---|---|
+| Cleanup manual_data SiHikingRoute | oc:7954 | `app/Console/Commands/CleanupSiHikingRoutesManualDataCommand.php` | Rimuove `properties->manual_data` dalle SiHikingRoute (app_id=2, layer_id=6) per ripristinare DEM come current value. Idempotente, supporta `--dry-run` e `-v`. |
+
 ### Configurazione dei Test
 I test usano un DB PostgreSQL/PostGIS reale (non SQLite in-memory). La connessione DB in `phpunit.xml` è lasciata non commentata per PostGIS.
 Suite di test: `Unit`, `Api`, `Feature` (sotto `tests/`).

--- a/app/Console/Commands/CleanupSiHikingRoutesManualDataCommand.php
+++ b/app/Console/Commands/CleanupSiHikingRoutesManualDataCommand.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\HikingRoute;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class CleanupSiHikingRoutesManualDataCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'osm2cai:cleanup-si-hiking-routes-manual-data
+                            {--dry-run : Run without writing to the database}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Removes manual_data from SiHikingRoute records (app_id=2, layer_id=6) to restore DEM values as the current value';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $isDryRun = $this->option('dry-run');
+        $isVerbose = $this->output->isVerbose();
+
+        if ($isDryRun) {
+            $this->warn('DRY RUN mode enabled: no database writes will be performed.');
+        }
+
+        $query = HikingRoute::query()
+            ->where('app_id', 2)
+            ->whereIn('id', function ($sub) {
+                $sub->select('layerable_id')
+                    ->from('layerables')
+                    ->where('layer_id', 6)
+                    ->where('layerable_type', HikingRoute::class);
+            })
+            ->whereNotNull('properties')
+            ->whereRaw("properties::jsonb ?? 'manual_data'");
+
+        $total = $query->count();
+
+        if ($total === 0) {
+            $this->info('No records with manual_data found. Nothing to do.');
+
+            return 0;
+        }
+
+        $this->info("Found {$total} records with the manual_data key.");
+
+        $cleaned = 0;
+        $skipped = 0;
+        $errors = 0;
+        $noDemIds = [];
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        $query->chunkById(100, function ($routes) use (
+            $isDryRun,
+            $isVerbose,
+            $bar,
+            &$cleaned,
+            &$skipped,
+            &$errors,
+            &$noDemIds,
+        ) {
+            foreach ($routes as $route) {
+                try {
+                    $properties = $route->properties;
+
+                    if (! is_array($properties)) {
+                        $skipped++;
+                        Log::info('osm2cai:cleanup-si-hiking-routes-manual-data: skip', [
+                            'id' => $route->id,
+                            'reason' => 'properties is not an array',
+                        ]);
+                        if ($isVerbose) {
+                            $this->newLine();
+                            $this->line("  SKIP [{$route->id}] properties is not an array");
+                        }
+                        $bar->advance();
+                        continue;
+                    }
+
+                    $manualData = $properties['manual_data'] ?? null;
+
+                    if (empty($manualData)) {
+                        $skipped++;
+                        Log::info('osm2cai:cleanup-si-hiking-routes-manual-data: skip', [
+                            'id' => $route->id,
+                            'reason' => 'manual_data is missing or empty',
+                        ]);
+                        if ($isVerbose) {
+                            $this->newLine();
+                            $this->line("  SKIP [{$route->id}] manual_data is missing or empty");
+                        }
+                        $bar->advance();
+                        continue;
+                    }
+
+                    Log::info('osm2cai:cleanup-si-hiking-routes-manual-data', [
+                        'id' => $route->id,
+                        'manual_data' => $manualData,
+                        'dry_run' => $isDryRun,
+                    ]);
+
+                    $demData = $properties['dem_data'] ?? null;
+                    $osmData = $properties['osm_data'] ?? null;
+                    if (empty($demData) && empty($osmData)) {
+                        $noDemIds[] = $route->id;
+                    }
+
+                    if (! $isDryRun) {
+                        unset($properties['manual_data']);
+                        $route->properties = $properties;
+                        $route->saveQuietly();
+                    }
+
+                    $cleaned++;
+                    if ($isVerbose) {
+                        $mode = $isDryRun ? 'DRY-RUN' : 'CLEANED';
+                        $this->newLine();
+                        $this->line("  {$mode} [{$route->id}]");
+                    }
+                } catch (\Throwable $e) {
+                    $errors++;
+                    $this->newLine();
+                    $this->warn("  ERROR [{$route->id}]: {$e->getMessage()}");
+                    Log::error('osm2cai:cleanup-si-hiking-routes-manual-data: record error', [
+                        'id' => $route->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+
+                $bar->advance();
+            }
+        });
+
+        $bar->finish();
+        $this->newLine(2);
+
+        $this->info("Cleaned: {$cleaned}");
+        $this->info("Skipped: {$skipped}");
+
+        if ($errors > 0) {
+            $this->warn("Errors: {$errors}");
+        }
+
+        if (! empty($noDemIds)) {
+            $this->newLine();
+            $this->warn('The following records were ' . ($isDryRun ? 'identified for cleanup' : 'cleaned') . ' but have neither DEM data nor OSM data available:');
+            $this->warn('IDs: ' . implode(', ', $noDemIds));
+        }
+
+        return 0;
+    }
+}

--- a/docs/features/7954-cleanup-si-hiking-routes-manual-data/notes.md
+++ b/docs/features/7954-cleanup-si-hiking-routes-manual-data/notes.md
@@ -1,0 +1,37 @@
+> Ticket: oc:7954
+
+# Notes — Cleanup manual_data su SiHikingRoute
+
+## Deviazioni dal piano
+
+### 1. `--verbose` → `-v` (flag built-in Symfony)
+Il piano prevedeva un'opzione custom `--verbose`. In fase di esecuzione è emerso
+che `--verbose` è già un'opzione nativa di Symfony Console e causa conflitto
+(`LogicException: An option named "verbose" already exists`).
+Soluzione: rimosso `--verbose` dalla signature, usato `$this->output->isVerbose()`
+che si attiva con il flag standard `-v` di Artisan.
+
+### 2. `chunk()` → `chunkById()` (bug offset shifting)
+Il piano usava `chunk(100)`. In fase di esecuzione reale è emerso che modificare
+i record durante l'iterazione (saveQuietly rimuove manual_data → il record esce
+dalla WHERE clause) causa lo spostamento dell'OFFSET, facendo saltare record.
+Primo lancio: 295/520 puliti invece di 520.
+Soluzione: sostituito con `chunkById(100)` che pagina per ID e non risente delle
+modifiche alla result set. Secondo lancio (idempotente): puliti i restanti 225.
+
+### 3. Operatore `?` PostgreSQL → `??` in whereRaw
+PDO interpreta `?` come placeholder di bind. Necessario raddoppiare in `??`
+per escaparlo correttamente in `whereRaw`.
+
+## Bug trovati
+- `chunk()` + modifica della result set durante l'iterazione = record saltati.
+  Pattern pericoloso da evitare in tutti i command che modificano i record
+  su cui stanno iterando. Preferire sempre `chunkById()` in questi casi.
+
+## Decisioni
+- Il command è stato rilanciato una seconda volta sfruttando l'idempotenza.
+  Nessun dato è andato perso né duplicato.
+- Nessun record senza DEM/OSM data — il warning finale non è apparso.
+
+## Follow-up
+- Nessuno. Il cleanup è completo: 520 record puliti, 5 skippati (manual_data vuoto).

--- a/docs/features/7954-cleanup-si-hiking-routes-manual-data/overview.md
+++ b/docs/features/7954-cleanup-si-hiking-routes-manual-data/overview.md
@@ -1,0 +1,39 @@
+> Ticket: oc:7954
+
+# Cleanup manual_data su SiHikingRoute
+
+## Cosa cambia
+Viene aggiunto un command Artisan rilanciabile che rimuove la chiave `manual_data`
+dall'oggetto JSONB `properties` delle SiHikingRoute (app_id=2, layer_id=6).
+Dopo la pulizia, il sistema di priorità `HasDemClassification` mostrerà come
+"current value" i dati DEM (o OSM) invece di quelli manuali.
+
+## Perché
+I dati `manual_data` presenti sulle SiHikingRoute sovrascrivono i valori DEM nel
+pannello Nova (tab DEM, colonna CURRENT VALUE). Rimuoverli permette di visualizzare
+i dati calcolati automaticamente, che sono più affidabili per il contesto SICAI.
+
+## Requisiti
+- [ ] Command `osm2cai:cleanup-si-hiking-routes-manual-data` in `app/Console/Commands/`
+- [ ] Filtra solo record con `app_id = 2` associati a `layer_id = 6` via tabella `layerables`
+- [ ] Idempotente: skippa record con `properties = null` o `manual_data` assente/vuoto
+- [ ] Rimuove la chiave `manual_data` da `properties` e salva con `saveQuietly()`
+- [ ] Flag `--dry-run`: esegue tutto il flusso senza scrivere sul DB
+- [ ] Flag `--verbose`: stampa l'ID di ogni record processato o skippato
+- [ ] `Log::info()` con ID e valori di `manual_data` prima di ogni rimozione (anche in dry-run)
+- [ ] Recap finale: contatori `cleaned` / `skipped` / `errors`
+- [ ] Warning finale con lista ID dei record puliti ma privi di `dem_data` (e `osm_data`)
+
+## Rischi
+- **Irreversibilità**: la rimozione non è annullabile senza ripristino DB.
+  Mitigato con `--dry-run` obbligatorio prima del lancio reale, e `Log::info()` che
+  conserva i valori rimossi nei log Laravel.
+
+## Out of scope
+- HikingRoute con `app_id = 1` (osm2cai standard): non vengono toccate
+- Record con `app_id = 2` ma non nel `layer_id = 6`: non vengono toccati
+- Aggiunta di una guardia su `dem_data` prima della rimozione
+- Backup automatico dei valori rimossi su tabella separata
+
+## Moduli toccati
+- `app/Console/Commands/CleanupSiHikingRoutesManualDataCommand.php` — nuovo file

--- a/docs/features/7954-cleanup-si-hiking-routes-manual-data/plan.md
+++ b/docs/features/7954-cleanup-si-hiking-routes-manual-data/plan.md
@@ -1,0 +1,168 @@
+> Ticket: oc:7954
+
+# Plan — Cleanup manual_data su SiHikingRoute
+
+## File da creare
+| File | Repo | Operazione |
+|---|---|---|
+| `app/Console/Commands/CleanupSiHikingRoutesManualDataCommand.php` | osm2cai2 | Nuovo |
+
+Nessun file esistente da modificare. Laravel auto-carica i command da `app/Console/Commands/` via `Kernel::load()`.
+
+**Commit convention:** `feat(oc:7954): ...`
+
+---
+
+## Step 1 — Crea il command
+
+**File:** `app/Console/Commands/CleanupSiHikingRoutesManualDataCommand.php`
+
+### Signature e description
+
+```php
+protected $signature = 'osm2cai:cleanup-si-hiking-routes-manual-data
+                        {--dry-run : Esegui senza scrivere sul database}
+                        {--verbose : Stampa l\'ID di ogni record processato o skippato}';
+
+protected $description = 'Rimuove manual_data dalle SiHikingRoute (app_id=2, layer_id=6) per ripristinare i valori DEM come current value';
+```
+
+### Struttura handle()
+
+```
+handle()
+├── leggi opzioni: $isDryRun, $isVerbose
+├── stampa header (dry-run se attivo)
+├── build query SiHikingRoute (app_id=2, layer_id=6, ha manual_data non vuoto)
+├── conta totale da processare
+├── se totale = 0 → info "Nessun record da pulire" → return 0
+├── crea progress bar sul totale
+├── chunk(100) → per ogni record:
+│   ├── skip se properties null        → contatore $skipped++, verbose log
+│   ├── skip se manual_data assente    → contatore $skipped++, verbose log
+│   ├── skip se manual_data vuoto []   → contatore $skipped++, verbose log
+│   ├── Log::info() con id + manual_data values
+│   ├── se !$isDryRun → unset + saveQuietly()
+│   ├── traccia se dem_data assente (e osm_data assente) → $noDemIds[]
+│   └── contatore $cleaned++
+├── progress bar finish
+├── stampa recap finale
+│   ├── cleaned / skipped / errors
+│   └── se $noDemIds non vuoto → warning con lista ID
+└── return 0
+```
+
+### Query di selezione
+
+```php
+use App\Models\HikingRoute;
+use Illuminate\Support\Facades\DB;
+
+$query = HikingRoute::query()
+    ->where('app_id', 2)
+    ->whereIn('id', function ($sub) {
+        $sub->select('layerable_id')
+            ->from('layerables')
+            ->where('layer_id', 6)
+            ->where('layerable_type', HikingRoute::class);
+    })
+    ->whereNotNull('properties')
+    ->whereRaw("properties::jsonb ? 'manual_data'");
+```
+
+> Il filtro `whereRaw("properties::jsonb ? 'manual_data'")` seleziona solo i record
+> che hanno la chiave nel JSONB, evitando di caricare tutti i record in memoria.
+> Il check "manual_data non vuoto" viene fatto a livello PHP nel loop per gestire
+> correttamente array vuoti `[]` senza una query JSONB aggiuntiva.
+
+### Logica per singolo record (dentro chunk)
+
+```php
+$properties = $route->properties;
+
+// skip: properties null
+if (! is_array($properties)) {
+    $skipped++;
+    if ($isVerbose) $this->line("  SKIP [{$route->id}] properties non è array");
+    $bar->advance();
+    continue;
+}
+
+// skip: manual_data assente o vuoto
+$manualData = $properties['manual_data'] ?? null;
+if (empty($manualData)) {
+    $skipped++;
+    if ($isVerbose) $this->line("  SKIP [{$route->id}] manual_data assente o vuoto");
+    $bar->advance();
+    continue;
+}
+
+// log pre-rimozione (anche in dry-run)
+Log::info('cleanup-si-hiking-routes-manual-data: rimozione manual_data', [
+    'id'          => $route->id,
+    'manual_data' => $manualData,
+    'dry_run'     => $isDryRun,
+]);
+
+// traccia record senza DEM né OSM
+$demData = $properties['dem_data'] ?? null;
+$osmData = $properties['osm_data'] ?? null;
+if (empty($demData) && empty($osmData)) {
+    $noDemIds[] = $route->id;
+}
+
+if (! $isDryRun) {
+    unset($properties['manual_data']);
+    $route->properties = $properties;
+    $route->saveQuietly();
+}
+
+$cleaned++;
+if ($isVerbose) {
+    $mode = $isDryRun ? 'DRY-RUN' : 'CLEANED';
+    $this->line("  {$mode} [{$route->id}]");
+}
+$bar->advance();
+```
+
+### Recap finale
+
+```php
+$this->newLine(2);
+$this->info("✅ Puliti:  {$cleaned}");
+$this->info("⏭️  Saltati: {$skipped}");
+if ($errors > 0) {
+    $this->warn("❌ Errori:  {$errors}");
+}
+if (! empty($noDemIds)) {
+    $this->newLine();
+    $this->warn('⚠️  I seguenti record sono stati puliti ma non hanno DEM né OSM data disponibile:');
+    $this->warn('   ID: ' . implode(', ', $noDemIds));
+}
+```
+
+---
+
+## Step 2 — Verifica manuale post-implementazione
+
+Prima del commit, lanciare nell'ambiente locale:
+
+```bash
+# Dry-run per verifica
+docker exec -it php81-osm2cai2 php artisan osm2cai:cleanup-si-hiking-routes-manual-data --dry-run --verbose
+
+# Lancio reale
+docker exec -it php81-osm2cai2 php artisan osm2cai:cleanup-si-hiking-routes-manual-data --verbose
+```
+
+Verificare in Nova che su una SiHikingRoute precedentemente con manual_data
+il tab DEM mostri CURRENT VALUE = DEM (o EMPTY se dem_data era assente).
+
+---
+
+## Note implementative
+
+- `saveQuietly()` bypassa `HikingRouteObserver` — nessun job di intersezione/prossimità viene dispatchato
+- `chunk(100)` evita out-of-memory su dataset grandi
+- Il command è idempotente: può essere rilanciato senza effetti su record già puliti
+- `whereRaw("properties::jsonb ? 'manual_data'")` richiede PostgreSQL/PostGIS (non SQLite) — coerente con la configurazione di test del progetto


### PR DESCRIPTION
Introduce a new console command to remove `manual_data` from `SiHikingRoute` records with `app_id=2, layer_id=6`. Supports `--dry-run` for safe execution without database writes and enhances data reliability by restoring DEM values as the current value. Implements verbose logging and error handling to ensure complete and accurate cleanup, adhering to idempotency for repeated runs.