### PR TITLE
fix(oc:8197): dispatch WMFE/PBF sync for children updated via saveQuietly

### DIFF
--- a/app/Observers/HikingRouteObserver.php
+++ b/app/Observers/HikingRouteObserver.php
@@ -148,6 +148,14 @@ class HikingRouteObserver extends EcTrackObserver
             $child->validation_date = $newValidationDate;
 
             $child->saveQuietly();
+
+            // saveQuietly() bypassa gli Observer: la sync verso WMFE (e, se serve, PBF)
+            // deve essere dispatchata esplicitamente qui. Vedi oc:8197.
+            UpdateEcTrackAwsJob::dispatch($child);
+
+            if ($child->wasChanged('geometry')) {
+                $this->updatePbfsForHikingRoute($child);
+            }
         }
     }
 

--- a/docs/features/8197-desincronizzazione-db-wmfe-pbf-tracce-si/notes.md
+++ b/docs/features/8197-desincronizzazione-db-wmfe-pbf-tracce-si/notes.md
@@ -1,0 +1,28 @@
+> Ticket: oc:8197
+
+# Notes — Desincronizzazione DB ↔ WMFE ↔ PBF su tracce aggiornate senza observer
+
+## Deviazioni dal piano
+
+- Il piano indicava `Queue::fake()` + `Queue::assertPushed()` per il test. L'implementer ha usato `Bus::fake()` + `Bus::assertDispatched()`/`Bus::batched()`: `Dispatchable::dispatch()` passa dal Bus, non dalla Queue facade — verificato che è lo stesso meccanismo già usato per il dispatch esistente nel metodo `saved()` del parent. Cambio tecnicamente necessario, non un'invenzione arbitraria.
+- Il piano accedeva a `$job->ecTrack->id` nell'assert; la proprietà è `protected` in `BaseEcTrackJob`, quindi l'implementer ha usato il getter pubblico `getEcTrack()->id`.
+
+## Bug trovati
+
+- Durante la Fase: challenge è stato individuato un bug distinto (non introdotto da questo fix, preesistente): `UpdateEcTrackAwsJob` ricarica sempre il modello tramite `config('wm-package.ec_track_model')`, fissato a `App\Models\HikingRoute`. Per una `SiHikingRoute` questo significa perdere l'override `getFeatureCollectionMap()` specifico. **Verificato con dati reali di produzione** (file `29360.json` su WMFE) che questo NON impatta il JSON effettivamente pubblicato: `EcTrackResource` costruisce `related_pois` leggendo direttamente la relazione `ecPois`, non passando da `getFeatureCollectionMap()`. Nessuna azione necessaria, nessun ticket aperto per questo.
+
+## Decisioni
+
+- Scope limitato alla causa certa (propagazione ai figli via `saveQuietly()` in `HikingRouteObserver::syncOsm2caiStatusToChildSiHikingRoutes()`), escludendo deliberatamente altri path `saveQuietly()`/`updateQuietly()` esistenti (sync osmfeatures bulk, `ForceUpdateOsmFeaturesFromTo`, SignageMap, cleanup SI) e il servizio centralizzato `EcTrackSyncService` proposto nel ticket come soluzione a medio termine.
+- Verificato via query DB che nessuna SiHikingRoute figlia ha a sua volta figli (0 "nipoti") — nessun rischio di ricorsione con l'approccio scelto (dispatch esplicito dopo `saveQuietly()`, non sostituzione con `save()`).
+- Creato ticket parallelo **oc:8200** per la rigenerazione forzata WMFE/PBF su tutte le tracce SI esistenti (app_id=2, ~1188 record) — decisione presa con l'utente di non costruire una logica di detection (rischio falsi negativi su `geometry_sync`) ma rigenerare direttamente tutto il target.
+
+## Review formale (wm-review-ticket)
+
+- 5 finder paralleli: nessun finding bloccante, solo cleanup. Corretto subito: rimosse 2 chiamate ridondanti a `Queue::fake()` nel test (dead code, l'assert reale passa da `Bus::fake()`/`Bus::assertDispatched()`/`Bus::batched()`). Test rieseguiti dopo la pulizia: 2/2 PASS.
+- Lasciati come follow-up (non correttivi per questo ciclo): duplicazione della logica di dispatch tra `saved()` e `syncOsm2caiStatusToChildSiHikingRoutes()` (debito tecnico, refactor da valutare separatamente), accoppiamento del test all'esatto formato stringa del nome batch PBF (minor).
+
+## Follow-up
+
+- oc:8200 — rigenerazione forzata WMFE/PBF per tutte le HikingRoute con `app_id=2`, incluse le due tracce segnalate nel ticket originale (`29360`, `29369`). **Rafforzato durante la review finale**: verificato sul DB che coppie parent/figlio con lo stesso `osmfeatures_id` hanno spesso geometrie diverse (`same_geom = false`) — segno che la desincronizzazione è un pattern più ampio del previsto, non isolato alle due tracce segnalate. Conferma che la scelta di rigenerare tutto il target (senza logica di detection puntuale) in oc:8200 è quella giusta.
+- Non tracciato in un ticket dedicato (volutamente, vedi "Bug trovati" sopra): l'incoerenza `UpdateEcTrackAwsJob` vs classe reale del modello (`HikingRoute` vs `SiHikingRoute`) — nessun impatto verificato sul JSON pubblicato, monitorare se in futuro `EcTrackResource` dovesse iniziare a usare `getFeatureCollectionMap()`.

--- a/docs/features/8197-desincronizzazione-db-wmfe-pbf-tracce-si/overview.md
+++ b/docs/features/8197-desincronizzazione-db-wmfe-pbf-tracce-si/overview.md
@@ -1,0 +1,40 @@
+> Ticket: oc:8197
+
+# Desincronizzazione DB ↔ WMFE ↔ PBF su tracce aggiornate senza observer
+
+## Cosa cambia
+
+`HikingRouteObserver::syncOsm2caiStatusToChildSiHikingRoutes()` propaga `osm2cai_status`, `validator_id` e `validation_date` da una HikingRoute parent alle SiHikingRoute figlie usando `saveQuietly()`. Questo bypassa gli Observer Laravel e quindi salta il dispatch di `UpdateEcTrackAwsJob` (sync WMFE) e della rigenerazione PBF, lasciando le tracce figlie con dati validi nel DB ma versioni obsolete su mappa/app.
+
+Il fix dispatcha esplicitamente, subito dopo il `saveQuietly()` di ogni figlio effettivamente cambiato:
+- `UpdateEcTrackAwsJob` sempre (sync WMFE)
+- la rigenerazione PBF (`updatePbfsForHikingRoute()`) solo se il figlio ha anche una modifica di geometria (`wasChanged('geometry')`) — questo metodo modifica solo `osm2cai_status`/`validator_id`/`validation_date` sul figlio, mai la geometria, quindi in pratica oggi questo branch non scatta mai. La maggioranza dei figli (517 su 548, verificato sul DB) ha un `osmfeatures_id` proprio e riceve la propria geometria da un sync OSM indipendente, non dal parent — la condizione resta comunque corretta come guardia se in futuro il metodo venisse estesa a toccare anche la geometria.
+
+## Perché
+
+Segnalato dall'utente su tracce SI validate (`osm2cai_status = 4`), figlie di un parent: backoffice mostra dati corretti, mappa/app mostrano la versione precedente (`geometry_sync = false`). Causa identificata: `saveQuietly()` sui figli bypassa `saved()`/`updated()` degli Observer, che sono l'unico punto che dispatcha la sync verso WMFE e PBF.
+
+## Requisiti
+
+- [ ] `syncOsm2caiStatusToChildSiHikingRoutes()` dispatcha `UpdateEcTrackAwsJob` per ogni figlio effettivamente modificato
+- [ ] `syncOsm2caiStatusToChildSiHikingRoutes()` dispatcha la rigenerazione PBF per il figlio solo se `wasChanged('geometry')` è true sul figlio
+- [ ] Nessuna modifica al comportamento per i campi non toccati da questo metodo (nessuna regressione su altri Observer/side-effect)
+- [ ] Test automatico (`Queue::fake()`) che verifica che l'aggiornamento di `osm2cai_status` su un parent dispatchi `UpdateEcTrackAwsJob` anche per i figli propagati via `saveQuietly()`
+
+## Rischi
+
+- Nessun rischio di ricorsione: verificato via query sul DB locale che nessuna SiHikingRoute figlia ha a sua volta figli (0 nipoti).
+- Il fix non copre altri path che usano `saveQuietly()`/`updateQuietly()` (sync osmfeatures bulk, `ForceUpdateOsmFeaturesFromTo`, SignageMap, cleanup SI) — questi possono generare lo stesso sintomo e sono esplicitamente out of scope.
+- Le tracce già desincronizzate in produzione (es. `29360`, `29369`, e altre non ancora identificate) non vengono corrette da questo fix, che previene solo nuove desincronizzazioni dal path corretto — gestite dal ticket parallelo oc:8200.
+
+## Out of scope
+
+- Fix di altri path `saveQuietly()`/`updateQuietly()` che bypassano gli observer (bulk osmfeatures sync, `ForceUpdateOsmFeaturesFromTo`, SignageMap, cleanup SI)
+- Rigenerazione/audit dei dati storici già desincronizzati → tracciato in **oc:8200**
+- Servizio centralizzato `EcTrackSyncService::syncToWmfeAndPbf()` proposto nel ticket come soluzione a medio termine (non necessario per chiudere la causa specifica di questo bug)
+- Compensazione WMFE nella sync osmfeatures bulk (esiste già solo per PBF)
+
+## Moduli toccati
+
+- `app/Observers/HikingRouteObserver.php` — metodo `syncOsm2caiStatusToChildSiHikingRoutes()`
+- Nuovo test: `tests/Unit/Observers/HikingRouteObserverTest.php`

--- a/docs/features/8197-desincronizzazione-db-wmfe-pbf-tracce-si/plan.md
+++ b/docs/features/8197-desincronizzazione-db-wmfe-pbf-tracce-si/plan.md
@@ -1,0 +1,249 @@
+> Ticket: oc:8197
+
+# Fix propagazione sync WMFE/PBF su figli SiHikingRoute Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Far propagare la sync WMFE (e, se serve, PBF) alle SiHikingRoute figlie quando `HikingRouteObserver::syncOsm2caiStatusToChildSiHikingRoutes()` le aggiorna con `saveQuietly()`, così i figli non restano desincronizzati dopo che il parent cambia `osm2cai_status`/`validator_id`/`validation_date`.
+
+**Architecture:** `saveQuietly()` sui figli resta invariato (evita di alterare altri side-effect dell'observer sui figli), ma subito dopo ogni `saveQuietly()` di un figlio effettivamente cambiato si dispatcha esplicitamente `UpdateEcTrackAwsJob` (sempre) e la rigenerazione PBF via `updatePbfsForHikingRoute()` (solo se il figlio ha anche `wasChanged('geometry')`). Nessuna nuova classe: una sola modifica mirata dentro `HikingRouteObserver`.
+
+**Tech Stack:** Laravel 11, PHPUnit (`php artisan test`), `Queue::fake()`.
+
+## Global Constraints
+
+- Non introdurre `EcTrackSyncService` o altre astrazioni: modifica mirata al solo metodo indicato.
+- Non toccare altri path `saveQuietly()`/`updateQuietly()` (sync osmfeatures bulk, `ForceUpdateOsmFeaturesFromTo`, SignageMap, cleanup SI) — fuori scope.
+- Non modificare i dati storici già desincronizzati (tracce `29360`, `29369`, ecc.) — gestiti dal ticket parallelo oc:8200.
+- Nessun commit/branch automatico: ogni commit indicato nel piano è un'istruzione testuale per lo sviluppatore, da eseguire solo dopo revisione.
+
+---
+
+## Task 1: Fix propagazione sync nei figli SiHikingRoute
+
+**Files:**
+- Modify: `app/Observers/HikingRouteObserver.php:132-152` (metodo `syncOsm2caiStatusToChildSiHikingRoutes`)
+- Test: `tests/Unit/Observers/HikingRouteObserverTest.php` (nuovo file)
+
+**Interfaces:**
+- Consumes: `Wm\WmPackage\Jobs\Track\UpdateEcTrackAwsJob` (già importato in cima al file, usato in `saved()` come `UpdateEcTrackAwsJob::dispatch($hikingRoute)`), `HikingRouteObserver::updatePbfsForHikingRoute($hikingRoute): void` (metodo privato già esistente nello stesso file, righe 36-73), `HikingRoute::childHikingRoutes(): HasMany` (relazione già esistente in `app/Models/HikingRoute.php:435-438`).
+- Produces: nessuna nuova interfaccia pubblica — il comportamento osservabile è: dopo il salvataggio di un parent con cambio di `osm2cai_status`/`validator_id`/`validation_date`, ogni figlio con quei campi effettivamente cambiati riceve un dispatch di `UpdateEcTrackAwsJob` (sempre) e di `updatePbfsForHikingRoute` (solo se il figlio ha anche `wasChanged('geometry')`).
+
+- [ ] **Step 1: Scrivere il test che fallisce**
+
+Crea `tests/Unit/Observers/HikingRouteObserverTest.php`:
+
+```php
+<?php
+
+namespace Tests\Unit\Observers;
+
+use App\Models\HikingRoute;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+use Wm\WmPackage\Jobs\Track\UpdateEcTrackAwsJob;
+
+class HikingRouteObserverTest extends TestCase
+{
+    /** @test */
+    public function it_dispatches_update_ec_track_aws_job_for_child_when_parent_status_changes()
+    {
+        Queue::fake();
+
+        $parent = HikingRoute::factory()->create([
+            'osm2cai_status' => 3,
+            'validator_id' => null,
+            'validation_date' => null,
+        ]);
+
+        $child = HikingRoute::factory()->create([
+            'parent_hiking_route_id' => $parent->id,
+            'osm2cai_status' => 3,
+            'validator_id' => null,
+            'validation_date' => null,
+        ]);
+
+        Queue::fake();
+
+        $parent->osm2cai_status = 4;
+        $parent->save();
+
+        Queue::assertPushed(UpdateEcTrackAwsJob::class, function ($job) use ($child) {
+            return $job->ecTrack->id === $child->id;
+        });
+    }
+
+    /** @test */
+    public function it_does_not_dispatch_pbf_regeneration_for_child_when_only_status_changes()
+    {
+        Queue::fake();
+
+        $parent = HikingRoute::factory()->create([
+            'osm2cai_status' => 3,
+            'validator_id' => null,
+            'validation_date' => null,
+        ]);
+
+        $child = HikingRoute::factory()->create([
+            'parent_hiking_route_id' => $parent->id,
+            'osm2cai_status' => 3,
+            'validator_id' => null,
+            'validation_date' => null,
+        ]);
+
+        Queue::fake();
+
+        $parent->osm2cai_status = 4;
+        $parent->save();
+
+        Queue::assertNotPushed(\Illuminate\Bus\PendingBatch::class);
+        Queue::assertNothingPushed();
+    }
+}
+```
+
+Nota: il secondo test usa `Queue::assertNothingPushed()` solo per la parte PBF — dato che `UpdateEcTrackAwsJob` viene dispatchato comunque, questo secondo test così scritto fallirebbe anche sull'assert corretto. Sostituiscilo con un controllo più preciso al Step 3 (verrà corretto lì sotto, vedi Step 3b).
+
+- [ ] **Step 2: Eseguire il test e verificare che falisca**
+
+Run: `docker exec -it php-osm2cai2 php artisan test tests/Unit/Observers/HikingRouteObserverTest.php`
+Expected: FAIL — `it_dispatches_update_ec_track_aws_job_for_child_when_parent_status_changes` fallisce perché `UpdateEcTrackAwsJob` non viene dispatchato per il figlio (viene dispatchato solo per il parent).
+
+- [ ] **Step 3: Correggere il secondo test per un assert preciso**
+
+Il secondo test verifica che *non* venga generato un batch di rigenerazione PBF per il figlio quando cambia solo lo status (nessun cambio di geometria sul figlio). Sostituisci il corpo del secondo test con:
+
+```php
+    /** @test */
+    public function it_does_not_dispatch_pbf_batch_for_child_when_only_status_changes()
+    {
+        Queue::fake();
+
+        $parent = HikingRoute::factory()->create([
+            'osm2cai_status' => 3,
+            'validator_id' => null,
+            'validation_date' => null,
+        ]);
+
+        $child = HikingRoute::factory()->create([
+            'parent_hiking_route_id' => $parent->id,
+            'osm2cai_status' => 3,
+            'validator_id' => null,
+            'validation_date' => null,
+        ]);
+
+        Queue::fake();
+
+        $parent->osm2cai_status = 4;
+        $parent->save();
+
+        \Illuminate\Support\Facades\Bus::assertNothingBatched();
+    }
+```
+
+Aggiungi in cima al file l'uso di `Illuminate\Support\Facades\Bus` (o mantieni il namespace completo come sopra) e aggiungi `Bus::fake();` subito dopo `Queue::fake();` nel setup di entrambi i test:
+
+```php
+        Queue::fake();
+        \Illuminate\Support\Facades\Bus::fake();
+```
+
+Aggiorna anche il primo test aggiungendo `\Illuminate\Support\Facades\Bus::fake();` dopo il secondo `Queue::fake();`, per coerenza (non è strettamente necessario per l'asserzione ma evita che un batch reale venga dispatchato durante il test).
+
+- [ ] **Step 4: Eseguire di nuovo il test e verificare che falisca in modo coerente**
+
+Run: `docker exec -it php-osm2cai2 php artisan test tests/Unit/Observers/HikingRouteObserverTest.php`
+Expected: FAIL — `it_dispatches_update_ec_track_aws_job_for_child_when_parent_status_changes` fallisce (nessun `UpdateEcTrackAwsJob` per il figlio); `it_does_not_dispatch_pbf_batch_for_child_when_only_status_changes` PASSA già (nessun batch viene dispatchato oggi per i figli, quindi questo comportamento è già corretto e serve come test di non-regressione).
+
+- [ ] **Step 5: Implementare il fix minimo**
+
+Apri `app/Observers/HikingRouteObserver.php` e modifica il metodo `syncOsm2caiStatusToChildSiHikingRoutes` (righe 132-152) da:
+
+```php
+    private function syncOsm2caiStatusToChildSiHikingRoutes($hikingRoute): void
+    {
+        $newStatus = $hikingRoute->osm2cai_status;
+        $newValidatorId = $hikingRoute->validator_id;
+        $newValidationDate = $hikingRoute->validation_date;
+        $children = $hikingRoute->childHikingRoutes()->get();
+
+        foreach ($children as $child) {
+            $changed = $child->osm2cai_status !== $newStatus
+                || $child->validator_id !== $newValidatorId
+                || $child->validation_date?->format('Y-m-d') !== $newValidationDate?->format('Y-m-d');
+            if (! $changed) {
+                continue;
+            }
+            $child->osm2cai_status = $newStatus;
+            $child->validator_id = $newValidatorId;
+            $child->validation_date = $newValidationDate;
+
+            $child->saveQuietly();
+        }
+    }
+```
+
+a:
+
+```php
+    private function syncOsm2caiStatusToChildSiHikingRoutes($hikingRoute): void
+    {
+        $newStatus = $hikingRoute->osm2cai_status;
+        $newValidatorId = $hikingRoute->validator_id;
+        $newValidationDate = $hikingRoute->validation_date;
+        $children = $hikingRoute->childHikingRoutes()->get();
+
+        foreach ($children as $child) {
+            $changed = $child->osm2cai_status !== $newStatus
+                || $child->validator_id !== $newValidatorId
+                || $child->validation_date?->format('Y-m-d') !== $newValidationDate?->format('Y-m-d');
+            if (! $changed) {
+                continue;
+            }
+            $child->osm2cai_status = $newStatus;
+            $child->validator_id = $newValidatorId;
+            $child->validation_date = $newValidationDate;
+
+            $child->saveQuietly();
+
+            // saveQuietly() bypassa gli Observer: la sync verso WMFE (e, se serve, PBF)
+            // deve essere dispatchata esplicitamente qui. Vedi oc:8197.
+            UpdateEcTrackAwsJob::dispatch($child);
+
+            if ($child->wasChanged('geometry')) {
+                $this->updatePbfsForHikingRoute($child);
+            }
+        }
+    }
+```
+
+- [ ] **Step 6: Eseguire il test e verificare che passi**
+
+Run: `docker exec -it php-osm2cai2 php artisan test tests/Unit/Observers/HikingRouteObserverTest.php`
+Expected: PASS — entrambi i test passano.
+
+- [ ] **Step 7: Eseguire l'intera suite Unit per verificare l'assenza di regressioni**
+
+Run: `docker exec -it php-osm2cai2 php artisan test --testsuite=Unit`
+Expected: PASS — nessun test esistente rotto dalla modifica.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/Observers/HikingRouteObserver.php tests/Unit/Observers/HikingRouteObserverTest.php
+git commit -m "fix(oc:8197): dispatch WMFE/PBF sync for children updated via saveQuietly"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Requisito "dispatchare UpdateEcTrackAwsJob per ogni figlio effettivamente modificato" → Task 1, Step 5.
+- Requisito "dispatchare rigenerazione PBF solo se wasChanged('geometry') sul figlio" → Task 1, Step 5 (condizione `if ($child->wasChanged('geometry'))`).
+- Requisito "nessuna modifica al comportamento per campi non toccati" → il fix aggiunge solo 2 righe dopo `saveQuietly()`, non toglie/altera nulla di esistente.
+- Requisito "test con Queue::fake() che verifica dispatch per i figli" → Task 1, Step 1-4.
+
+**Placeholder scan:** nessun TBD/TODO — tutti gli step hanno codice completo.
+
+**Type consistency:** `UpdateEcTrackAwsJob::dispatch($child)` usa la stessa classe già importata e usata in `saved()` sullo stesso file (`Wm\WmPackage\Jobs\Track\UpdateEcTrackAwsJob`); `updatePbfsForHikingRoute($child)` è lo stesso metodo privato già esistente, stessa firma (`$hikingRoute` generico, qui passato `$child`).

--- a/tests/Unit/Observers/HikingRouteObserverTest.php
+++ b/tests/Unit/Observers/HikingRouteObserverTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\Observers;
+
+use App\Models\HikingRoute;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+use Wm\WmPackage\Jobs\Track\UpdateEcTrackAwsJob;
+
+class HikingRouteObserverTest extends TestCase
+{
+    /** @test */
+    public function it_dispatches_update_ec_track_aws_job_for_child_when_parent_status_changes()
+    {
+        Queue::fake();
+        Bus::fake();
+
+        $parent = HikingRoute::factory()->create([
+            'osm2cai_status' => 3,
+            'validator_id' => null,
+            'validation_date' => null,
+            'geometry' => DB::raw("ST_GeomFromText('LINESTRINGZ(12.4924 41.8902 0, 12.4925 41.8903 0)', 4326)"),
+        ]);
+
+        $child = HikingRoute::factory()->create([
+            'parent_hiking_route_id' => $parent->id,
+            'osm2cai_status' => 3,
+            'validator_id' => null,
+            'validation_date' => null,
+            'geometry' => DB::raw("ST_GeomFromText('LINESTRINGZ(12.4924 41.8902 0, 12.4925 41.8903 0)', 4326)"),
+        ]);
+
+        $parent->osm2cai_status = 4;
+        $parent->save();
+
+        Bus::assertDispatched(UpdateEcTrackAwsJob::class, function ($job) use ($child) {
+            return $job->getEcTrack()->id === $child->id;
+        });
+    }
+
+    /** @test */
+    public function it_does_not_dispatch_pbf_batch_for_child_when_only_status_changes()
+    {
+        Queue::fake();
+        Bus::fake();
+
+        $parent = HikingRoute::factory()->create([
+            'osm2cai_status' => 3,
+            'validator_id' => null,
+            'validation_date' => null,
+            'geometry' => DB::raw("ST_GeomFromText('LINESTRINGZ(12.4924 41.8902 0, 12.4925 41.8903 0)', 4326)"),
+        ]);
+
+        $child = HikingRoute::factory()->create([
+            'parent_hiking_route_id' => $parent->id,
+            'osm2cai_status' => 3,
+            'validator_id' => null,
+            'validation_date' => null,
+            'geometry' => DB::raw("ST_GeomFromText('LINESTRINGZ(12.4924 41.8902 0, 12.4925 41.8903 0)', 4326)"),
+        ]);
+
+        $parent->osm2cai_status = 4;
+        $parent->save();
+
+        $childBatches = Bus::batched(function ($batch) use ($child) {
+            return str_contains($batch->name, "Track {$child->id}:");
+        });
+
+        $this->assertCount(0, $childBatches, 'Non deve essere generato un batch PBF per il figlio quando cambia solo lo status.');
+    }
+}


### PR DESCRIPTION
## Summary
- `HikingRouteObserver::syncOsm2caiStatusToChildSiHikingRoutes()` propagava `osm2cai_status`/`validator_id`/`validation_date` alle SiHikingRoute figlie con `saveQuietly()`, bypassando gli Observer e saltando la sync verso WMFE (`UpdateEcTrackAwsJob`) e PBF.
- Ora dispatcha esplicitamente `UpdateEcTrackAwsJob` per ogni figlio effettivamente cambiato, e la rigenerazione PBF solo se il figlio ha anche `wasChanged('geometry')`.
- Aggiunta documentazione feature in `docs/features/8197-desincronizzazione-db-wmfe-pbf-tracce-si/`.

## Test plan
- [x] Nuovo test `tests/Unit/Observers/HikingRouteObserverTest.php` (2/2 PASS)
- [x] Suite Unit completa eseguita: nessuna regressione introdotta (4 failed pre-esistenti, non correlati)
- [x] Review formale con 5 finder paralleli: nessun finding bloccante

Ticket: oc:8197

🤖 Generated with [Claude Code](https://claude.com/claude-code)